### PR TITLE
Implement speckit functionality

### DIFF
--- a/libs/pattern/src/Pattern/Graph.hs
+++ b/libs/pattern/src/Pattern/Graph.hs
@@ -1,9 +1,469 @@
--- | Graph representation and operations.
+-- | Graph Lens: Interpretive view of Pattern structures as graphs.
 --
--- This module provides the Graph type and operations for working with
--- graph representations of patterns.
-module Pattern.Graph where
+-- This module provides the Graph Lens feature, which enables interpreting
+-- Pattern structures as graph structures (nodes, relationships, walks) through
+-- a minimal, elegant design based on a single predicate.
+--
+-- == Overview
+--
+-- A Graph Lens provides an interpretive view of a Pattern as a graph structure.
+-- Rather than defining graph concepts (nodes, relationships, walks) as intrinsic
+-- properties of Pattern, they emerge through the lens's interpretation. This
+-- design enables multiple graph views of the same Pattern and supports
+-- higher-order graphs where relationships or entire graphs become nodes.
+--
+-- == Core Design
+--
+-- The Graph Lens consists of:
+--
+-- * @scopePattern@: The Pattern that defines the boundary for all graph operations.
+--   Only direct elements of this pattern are considered for graph structure.
+-- * @isNode@: A predicate determining which direct elements are nodes.
+--   All other graph concepts (relationships, walks) derive from this single predicate.
+--
+-- == Design Principles
+--
+-- 1. **Scope-bounded operations**: All graph operations only consider direct elements
+--    of @scopePattern@, never descending into nested structures.
+--
+-- 2. **Single predicate foundation**: Only @isNode@ is required. All other graph
+--    predicates (relationships, walks, etc.) are derived from this.
+--
+-- 3. **Context captured at construction**: If a predicate needs context, that context
+--    must be captured when the predicate is created, not during evaluation.
+--
+-- 4. **Interpretation, not intrinsic**: Graph structure is not a property of Pattern
+--    itself, but an interpretation through the lens.
+--
+-- == Categorical Interpretation
+--
+-- Graph Lens provides a functorial interpretation where Pattern structures are
+-- transformed into graph interpretations. The transformation Pattern → Graph
+-- interpretation is functorial in nature.
+--
+-- == Example
+--
+-- >>> let graphPattern = patternWith "graph" [pattern "a", pattern "b", patternWith "r1" [pattern "a", pattern "b"]]
+-- >>> let isAtomic (Pattern _ els) = null els
+-- >>> let atomicLens = GraphLens graphPattern isAtomic
+-- >>> nodes atomicLens
+-- [Pattern "a" [],Pattern "b" []]
+--
+-- See @design/graph-lens.md@ and @specs/023-graph-lens/quickstart.md@ for
+-- comprehensive examples and usage patterns.
+module Pattern.Graph
+  ( -- * Graph Lens Type
+    GraphLens(..)
+    -- * Node Operations
+  , nodes
+  , isNodeLens
+    -- * Relationship Operations
+  , isRelationship
+  , relationships
+  , source
+  , target
+  , reverseRel
+    -- * Walk Operations
+  , isWalk
+  , walks
+  , walkNodes
+    -- * Navigation Operations
+  , neighbors
+  , incidentRels
+  , degree
+    -- * Graph Analysis Operations
+  , connectedComponents  -- Requires Ord v
+  , bfs                   -- Requires Ord v
+  , findPath              -- Requires Ord v
+  ) where
 
--- Graph type and operations will be implemented here
--- See data-model.md and DESIGN.md for the specification
+import Pattern.Core (Pattern(..), pattern, patternWith)
+import Data.Maybe (mapMaybe)
+import qualified Data.Set as Set
+import qualified Data.Map as Map
+
+-- | A Graph Lens provides an interpretive view of a Pattern as a graph structure.
+-- 
+-- The lens consists of:
+-- * @scopePattern@: The Pattern that defines the boundary for all graph operations.
+--   Only direct elements of this pattern are considered for graph structure.
+-- * @isNode@: A predicate determining which direct elements are nodes.
+--   All other graph concepts (relationships, walks) derive from this predicate.
+--
+-- == Categorical Interpretation
+--
+-- Graph Lens provides a functorial interpretation where Pattern structures are
+-- transformed into graph interpretations. The transformation Pattern → Graph
+-- interpretation is functorial in nature.
+--
+-- == Design Principles
+--
+-- 1. Scope-bounded: All operations only consider direct elements of scopePattern
+-- 2. Single predicate foundation: Only isNode is required, all else derives
+-- 3. Context at construction: Predicate context captured when lens is created
+-- 4. Interpretation, not intrinsic: Graph structure is an interpretation, not
+--    a property of Pattern itself
+--
+-- == Example
+--
+-- >>> let atomicLens = GraphLens pattern (\(Pattern _ els) -> null els)
+-- >>> nodes atomicLens
+-- [[a], [b], [c]]
+data GraphLens v = GraphLens
+  { scopePattern :: Pattern v
+    -- ^ The Pattern that defines the graph scope
+  , isNode       :: Pattern v -> Bool
+    -- ^ Predicate determining which elements are nodes
+  }
+
+-- | Extract all nodes from the graph lens.
+--
+-- Nodes are direct elements of scopePattern that satisfy the isNode predicate.
+--
+-- == Time Complexity
+-- O(n) where n is the number of direct elements in scopePattern
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> nodes lens
+-- [[a], [b], [c]]
+nodes :: GraphLens v -> [Pattern v]
+nodes (GraphLens (Pattern _ elements) isNodePred) = 
+  filter isNodePred elements
+
+-- | Determine if a Pattern is a node according to the lens.
+--
+-- This is the context-aware version that uses the lens's isNode predicate.
+-- The lens parameter provides the predicate context.
+--
+-- Note: This function is named @isNodeLens@ to avoid conflict with the
+-- @isNode@ field accessor in the GraphLens record.
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> isNodeLens lens (pattern "a")
+-- True
+-- >>> isNodeLens lens (patternWith "rel" [pattern "a", pattern "b"])
+-- False
+isNodeLens :: GraphLens v -> Pattern v -> Bool
+isNodeLens (GraphLens _ isNodePred) p = isNodePred p
+
+-- * Relationship Operations
+
+-- | Determine if a Pattern is a relationship according to the lens.
+--
+-- A relationship is a non-node pattern with exactly two node elements.
+--
+-- == Properties
+-- * Must not be a node (does not satisfy isNode predicate)
+-- * Must have exactly two elements
+-- * Both elements must be nodes (according to the lens)
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> let rel = patternWith "knows" [pattern "Alice", pattern "Bob"]
+-- >>> isRelationship lens rel
+-- True
+isRelationship :: GraphLens v -> Pattern v -> Bool
+isRelationship lens@(GraphLens _ isNodePred) p@(Pattern _ els) =
+  not (isNodePred p) &&
+  length els == 2 &&
+  all (isNodeLens lens) els
+
+-- | Extract all relationships from the graph lens.
+--
+-- Relationships are non-node patterns with exactly two node elements.
+--
+-- == Time Complexity
+-- O(n) where n is the number of direct elements in scopePattern
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> relationships lens
+-- [[knows | [Alice], [Bob]], [likes | [Bob], [Charlie]]]
+relationships :: GraphLens v -> [Pattern v]
+relationships lens@(GraphLens (Pattern _ elements) _) =
+  filter (isRelationship lens) elements
+
+-- | Extract the source node from a relationship.
+--
+-- For directed relationships, the source is the first element.
+-- Returns Nothing if the pattern is not a relationship.
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> let rel = patternWith "knows" [pattern "Alice", pattern "Bob"]
+-- >>> source lens rel
+-- Just (pattern "Alice")
+source :: GraphLens v -> Pattern v -> Maybe (Pattern v)
+source lens p@(Pattern _ (s:_))
+  | isRelationship lens p = Just s
+  | otherwise = Nothing
+source _ _ = Nothing
+
+-- | Extract the target node from a relationship.
+--
+-- For directed relationships, the target is the second element.
+-- Returns Nothing if the pattern is not a relationship.
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> let rel = patternWith "knows" [pattern "Alice", pattern "Bob"]
+-- >>> target lens rel
+-- Just (pattern "Bob")
+target :: GraphLens v -> Pattern v -> Maybe (Pattern v)
+target lens p@(Pattern _ [_, t])
+  | isRelationship lens p = Just t
+  | otherwise = Nothing
+target _ _ = Nothing
+
+-- | Reverse the direction of a relationship pattern.
+--
+-- Swaps the first and second elements, effectively reversing the
+-- relationship direction.
+--
+-- == Example
+--
+-- >>> let rel = patternWith "knows" [pattern "Alice", pattern "Bob"]
+-- >>> reverseRel rel
+-- patternWith "knows" [pattern "Bob", pattern "Alice"]
+reverseRel :: Pattern v -> Pattern v
+reverseRel (Pattern v [a, b]) = Pattern v [b, a]
+reverseRel p = p  -- Return unchanged if not a 2-element pattern
+
+-- * Walk Operations
+
+-- | Check if a list of relationships are consecutively connected.
+--
+-- Relationships are consecutively connected if the target of one
+-- equals the source of the next.
+--
+-- == Internal Function
+-- This is an internal helper function used by isWalk.
+consecutivelyConnected :: Eq v => GraphLens v -> [Pattern v] -> Bool
+consecutivelyConnected lens rels =
+  case rels of
+    [] -> True
+    [_] -> True
+    (r1:r2:rest) ->
+      case (target lens r1, source lens r2) of
+        (Just t, Just s) -> t == s && consecutivelyConnected lens (r2:rest)
+        _ -> False
+
+-- | Determine if a Pattern is a walk according to the lens.
+--
+-- A walk is a non-node pattern whose elements are all relationships,
+-- where consecutive relationships share nodes (target of one equals
+-- source of next).
+--
+-- == Properties
+-- * Must not be a node (does not satisfy isNode predicate)
+-- * All elements must be relationships (according to the lens)
+-- * Consecutive relationships must be connected
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> let walk = patternWith "path" [rel1, rel2, rel3]
+-- >>> isWalk lens walk
+-- True
+isWalk :: Eq v => GraphLens v -> Pattern v -> Bool
+isWalk lens@(GraphLens _ isNodePred) p@(Pattern _ elements) =
+  not (isNodePred p) &&
+  all (isRelationship lens) elements &&
+  consecutivelyConnected lens elements
+
+-- | Extract all walks from the graph lens.
+--
+-- Walks are non-node patterns whose elements are all relationships,
+-- where consecutive relationships share nodes.
+--
+-- == Time Complexity
+-- O(n) where n is the number of direct elements in scopePattern
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> walks lens
+-- [[path | [rel1], [rel2], [rel3]]]
+walks :: Eq v => GraphLens v -> [Pattern v]
+walks lens@(GraphLens (Pattern _ elements) isNodePred) =
+  filter (isWalk lens) elements
+
+-- | Extract nodes from a walk in traversal order.
+--
+-- Returns the source of the first relationship, followed by the targets
+-- of subsequent relationships. Returns empty list if the pattern is not
+-- a valid walk.
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> let walk = patternWith "path" [rel1, rel2]
+-- >>> walkNodes lens walk
+-- [pattern "A", pattern "B", pattern "C"]
+walkNodes :: Eq v => GraphLens v -> Pattern v -> [Pattern v]
+walkNodes lens p@(Pattern _ rels)
+  | isWalk lens p = case rels of
+      [] -> []
+      (r:rest) -> case source lens r of
+        Just s -> s : mapMaybe (target lens) (r:rest)
+        Nothing -> []
+  | otherwise = []
+
+-- * Navigation Operations
+
+-- | Find all neighbors of a node.
+--
+-- Neighbors are nodes connected to the given node via relationships
+-- (either as source or target).
+--
+-- == Time Complexity
+-- O(r) where r is the number of relationships in the graph
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> neighbors lens (pattern "Alice")
+-- [pattern "Bob", pattern "Charlie"]
+neighbors :: Eq v => GraphLens v -> Pattern v -> [Pattern v]
+neighbors lens node =
+  let rels = relationships lens
+      connectedNodes = concatMap (\r -> 
+        case (source lens r, target lens r) of
+          (Just s, Just t) | s == node -> [t]
+                           | t == node -> [s]
+          _ -> []
+        ) rels
+  in connectedNodes
+
+-- | Find all relationships involving a node.
+--
+-- Returns relationships where the node is either source or target.
+--
+-- == Time Complexity
+-- O(r) where r is the number of relationships in the graph
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> incidentRels lens (pattern "Alice")
+-- [[knows | [Alice], [Bob]], [likes | [Charlie], [Alice]]]
+incidentRels :: Eq v => GraphLens v -> Pattern v -> [Pattern v]
+incidentRels lens node =
+  filter (\r ->
+    case (source lens r, target lens r) of
+      (Just s, _) | s == node -> True
+      (_, Just t) | t == node -> True
+      _ -> False
+    ) (relationships lens)
+
+-- | Compute the degree of a node (number of incident relationships).
+--
+-- The degree is the count of relationships where the node is either
+-- source or target.
+--
+-- == Time Complexity
+-- O(r) where r is the number of relationships in the graph
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> degree lens (pattern "Alice")
+-- 3
+degree :: Eq v => GraphLens v -> Pattern v -> Int
+degree lens node = length (incidentRels lens node)
+
+-- * Graph Analysis Operations
+
+-- | Find all connected components in the graph.
+--
+-- A connected component is a set of nodes that are reachable from
+-- each other via relationships. Returns a list of lists, where each
+-- inner list represents a component.
+--
+-- == Time Complexity
+-- O(n + r) where n is number of nodes and r is number of relationships
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> connectedComponents lens
+-- [[pattern "A", pattern "B", pattern "C"], [pattern "D", pattern "E"]]
+connectedComponents :: Ord v => GraphLens v -> [[Pattern v]]
+connectedComponents lens = findComponents lens (nodes lens) Set.empty []
+
+findComponents :: Ord v => GraphLens v -> [Pattern v] -> Set.Set (Pattern v) -> [[Pattern v]] -> [[Pattern v]]
+findComponents _ [] _ acc = reverse acc
+findComponents lens (n:ns) visited acc =
+  if Set.member n visited
+  then findComponents lens ns visited acc
+  else
+    let component = bfs lens n
+        newVisited = Set.union visited (Set.fromList component)
+        newAcc = component : acc
+    in findComponents lens ns newVisited newAcc
+
+-- | Perform breadth-first search from a starting node.
+--
+-- Returns all nodes reachable from the starting node via relationships.
+--
+-- == Time Complexity
+-- O(n + r) where n is number of nodes and r is number of relationships
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> bfs lens (pattern "Alice")
+-- [pattern "Alice", pattern "Bob", pattern "Charlie"]
+bfs :: Ord v => GraphLens v -> Pattern v -> [Pattern v]
+bfs lens start = bfsHelper lens Set.empty [start] []
+
+bfsHelper :: Ord v => GraphLens v -> Set.Set (Pattern v) -> [Pattern v] -> [Pattern v] -> [Pattern v]
+bfsHelper _ _ [] acc = reverse acc
+bfsHelper lens visited (n:queue) acc
+  | Set.member n visited = bfsHelper lens visited queue acc
+  | otherwise =
+      let newVisited = Set.insert n visited
+          newAcc = n : acc
+          nodeNeighbors = Pattern.Graph.neighbors lens n
+          newQueue = queue ++ filter (not . (`Set.member` newVisited)) nodeNeighbors
+      in bfsHelper lens newVisited newQueue newAcc
+
+-- | Find a path between two nodes if one exists.
+--
+-- Returns Just [nodes] if a path exists, Nothing otherwise.
+-- The path is a sequence of nodes connecting start to end.
+--
+-- == Time Complexity
+-- O(n + r) where n is number of nodes and r is number of relationships
+--
+-- == Example
+--
+-- >>> let lens = GraphLens pattern isAtomic
+-- >>> findPath lens (pattern "Alice") (pattern "Charlie")
+-- Just [pattern "Alice", pattern "Bob", pattern "Charlie"]
+findPath :: Ord v => GraphLens v -> Pattern v -> Pattern v -> Maybe [Pattern v]
+findPath lens start end
+  | start == end = Just [start]
+  | otherwise = findPathHelper lens Set.empty [(start, [start])] end
+
+findPathHelper :: Ord v => GraphLens v -> Set.Set (Pattern v) -> [(Pattern v, [Pattern v])] -> Pattern v -> Maybe [Pattern v]
+findPathHelper _ _ [] _ = Nothing
+findPathHelper lens visited ((n, path):queue) target
+  | n == target = Just (reverse path)
+  | Set.member n visited = findPathHelper lens visited queue target
+  | otherwise =
+      let newVisited = Set.insert n visited
+          nodeNeighbors = Pattern.Graph.neighbors lens n
+          newPaths = map (\neighbor -> (neighbor, neighbor:path)) nodeNeighbors
+          unvisitedPaths = filter (\(neighbor, _) -> not (Set.member neighbor newVisited)) newPaths
+          newQueue = queue ++ unvisitedPaths
+      in findPathHelper lens newVisited newQueue target
 

--- a/libs/pattern/tests/Spec/Pattern/GraphSpec.hs
+++ b/libs/pattern/tests/Spec/Pattern/GraphSpec.hs
@@ -1,12 +1,75 @@
 -- | Unit tests for Pattern.Graph module.
 module Spec.Pattern.GraphSpec where
 
+import Data.List (isPrefixOf)
 import Test.Hspec
+import Pattern.Core (Pattern(..), pattern, patternWith)
+import Pattern.Graph (GraphLens(..), nodes, isNodeLens)
 
 spec :: Spec
 spec = do
   describe "Pattern.Graph" $ do
-    -- Tests will be added here when implementation begins
-    it "placeholder test" $ do
-      True `shouldBe` True
+    
+    describe "GraphLens data structure (Phase 2: Foundational)" $ do
+      
+      it "T009: GraphLens construction with atomic predicate" $ do
+        let graphPattern = patternWith "graph"
+              [ pattern "a"
+              , pattern "b"
+              , pattern "c"
+              ]
+        let isAtomic (Pattern _ els) = null els
+        let lens = GraphLens graphPattern isAtomic
+        scopePattern lens `shouldBe` graphPattern
+        isNodeLens lens (pattern "a") `shouldBe` True
+        isNodeLens lens (pattern "b") `shouldBe` True
+      
+      it "T010: GraphLens with empty scopePattern" $ do
+        let emptyPattern = patternWith "empty" []
+        let isAtomic (Pattern _ els) = null els
+        let lens = GraphLens emptyPattern isAtomic
+        nodes lens `shouldBe` []
+    
+    describe "nodes function (Phase 2: Foundational)" $ do
+      
+      it "T013: nodes with atomic predicate" $ do
+        let graphPattern = patternWith "graph"
+              [ pattern "a"
+              , pattern "b"
+              , patternWith "rel" [pattern "a", pattern "b"]
+              ]
+        let isAtomic (Pattern _ els) = null els
+        let lens = GraphLens graphPattern isAtomic
+        let result = nodes lens
+        length result `shouldBe` 2
+        (pattern "a" `elem` result) `shouldBe` True
+        (pattern "b" `elem` result) `shouldBe` True
+      
+      it "T014: nodes with value-based predicate" $ do
+        let graphPattern = patternWith "graph"
+              [ pattern "node1"
+              , pattern "node2"
+              , pattern "notnode"
+              ]
+        let isNodeValue (Pattern v _) = "node" `isPrefixOf` v
+        let lens = GraphLens graphPattern isNodeValue
+        let result = nodes lens
+        length result `shouldBe` 2
+        (pattern "node1" `elem` result) `shouldBe` True
+        (pattern "node2" `elem` result) `shouldBe` True
+      
+      it "T016: nodes with empty Pattern scope" $ do
+        let emptyPattern = patternWith "empty" []
+        let isAtomic (Pattern _ els) = null els
+        let lens = GraphLens emptyPattern isAtomic
+        nodes lens `shouldBe` []
+      
+      it "T017: nodes with Pattern with no nodes (all fail predicate)" $ do
+        let graphPattern = patternWith "graph"
+              [ patternWith "rel1" [pattern "a", pattern "b"]
+              , patternWith "rel2" [pattern "b", pattern "c"]
+              ]
+        let isAtomic (Pattern _ els) = null els
+        let lens = GraphLens graphPattern isAtomic
+        nodes lens `shouldBe` []
 

--- a/specs/023-graph-lens/tasks.md
+++ b/specs/023-graph-lens/tasks.md
@@ -16,11 +16,11 @@
 
 **Purpose**: Prepare project structure and verify dependencies
 
-- [ ] T001 Review existing Pattern library structure in `libs/pattern/`
-- [ ] T002 [P] Verify Pattern.Core module provides required Pattern type and functions
-- [ ] T003 [P] Verify test infrastructure (hspec, QuickCheck) is configured in `libs/pattern/pattern.cabal`
-- [ ] T004 [P] Review design document at `design/graph-lens.md` for implementation details
-- [ ] T005 [P] Review analysis recommendations at `specs/022-graph-lens-review/analysis.md`
+- [X] T001 Review existing Pattern library structure in `libs/pattern/`
+- [X] T002 [P] Verify Pattern.Core module provides required Pattern type and functions
+- [X] T003 [P] Verify test infrastructure (hspec, QuickCheck) is configured in `libs/pattern/pattern.cabal`
+- [X] T004 [P] Review design document at `design/graph-lens.md` for implementation details
+- [X] T005 [P] Review analysis recommendations at `specs/022-graph-lens-review/analysis.md`
 
 **Checkpoint**: Project structure understood, dependencies confirmed, design documents reviewed
 
@@ -32,12 +32,12 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete
 
-- [ ] T006 Implement GraphLens data structure in `libs/pattern/src/Pattern/Graph.hs` with scopePattern and isNode fields
-- [ ] T007 Add Haddock documentation for GraphLens data structure including categorical interpretation in `libs/pattern/src/Pattern/Graph.hs`
-- [ ] T008 Add module header documentation explaining Graph Lens concept in `libs/pattern/src/Pattern/Graph.hs`
-- [ ] T009 [P] Write unit test for GraphLens construction in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
-- [ ] T010 [P] Write edge case test for empty scopePattern in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
-- [ ] T011 Run tests with timeout: `timeout 60 cabal test` to verify foundational tests pass
+- [X] T006 Implement GraphLens data structure in `libs/pattern/src/Pattern/Graph.hs` with scopePattern and isNode fields
+- [X] T007 Add Haddock documentation for GraphLens data structure including categorical interpretation in `libs/pattern/src/Pattern/Graph.hs`
+- [X] T008 Add module header documentation explaining Graph Lens concept in `libs/pattern/src/Pattern/Graph.hs`
+- [X] T009 [P] Write unit test for GraphLens construction in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
+- [X] T010 [P] Write edge case test for empty scopePattern in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
+- [X] T011 Run tests with timeout: `timeout 60 cabal test` to verify foundational tests pass
 - [ ] T012 Git commit: "feat: add GraphLens data structure - foundational"
 
 **Checkpoint**: GraphLens data structure complete and tested - user story implementation can now begin
@@ -52,21 +52,21 @@
 
 ### Tests for User Story 1
 
-- [ ] T013 [P] [US1] Write unit test for `nodes` function with atomic predicate in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
-- [ ] T014 [P] [US1] Write unit test for `nodes` function with value-based predicate in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
+- [X] T013 [P] [US1] Write unit test for `nodes` function with atomic predicate in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
+- [X] T014 [P] [US1] Write unit test for `nodes` function with value-based predicate in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
 - [ ] T015 [P] [US1] Write unit test for `isNode` function (context-aware) in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
-- [ ] T016 [P] [US1] Write edge case test for empty Pattern scope in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
-- [ ] T017 [P] [US1] Write edge case test for Pattern with no nodes (all fail predicate) in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
+- [X] T016 [P] [US1] Write edge case test for empty Pattern scope in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
+- [X] T017 [P] [US1] Write edge case test for Pattern with no nodes (all fail predicate) in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs`
 - [ ] T018 [P] [US1] Write property-based test for nodes function correctness in `libs/pattern/tests/Spec/Pattern/Properties.hs`
 
 ### Implementation for User Story 1
 
-- [ ] T019 [US1] Implement `nodes` function in `libs/pattern/src/Pattern/Graph.hs` (filters scopePattern elements by isNode predicate)
-- [ ] T020 [US1] Implement `isNode` function (context-aware version) in `libs/pattern/src/Pattern/Graph.hs` (handle field accessor conflict)
-- [ ] T021 [US1] Add Haddock documentation for `nodes` function in `libs/pattern/src/Pattern/Graph.hs`
-- [ ] T022 [US1] Add Haddock documentation for `isNode` function in `libs/pattern/src/Pattern/Graph.hs`
-- [ ] T023 [US1] Update module export list in `libs/pattern/src/Pattern/Graph.hs` to export nodes and isNode
-- [ ] T024 [US1] Run tests with timeout: `timeout 60 cabal test` to verify all User Story 1 tests pass
+- [X] T019 [US1] Implement `nodes` function in `libs/pattern/src/Pattern/Graph.hs` (filters scopePattern elements by isNode predicate)
+- [X] T020 [US1] Implement `isNode` function (context-aware version) in `libs/pattern/src/Pattern/Graph.hs` (handle field accessor conflict)
+- [X] T021 [US1] Add Haddock documentation for `nodes` function in `libs/pattern/src/Pattern/Graph.hs`
+- [X] T022 [US1] Add Haddock documentation for `isNode` function in `libs/pattern/src/Pattern/Graph.hs`
+- [X] T023 [US1] Update module export list in `libs/pattern/src/Pattern/Graph.hs` to export nodes and isNode
+- [X] T024 [US1] Run tests with timeout: `timeout 60 cabal test` to verify all User Story 1 tests pass
 - [ ] T025 [US1] Git commit: "feat: implement node identification - US1"
 
 **Checkpoint**: At this point, User Story 1 should be fully functional and testable independently. Developers can create GraphLens and identify nodes.


### PR DESCRIPTION
Implement the foundational GraphLens data structure and all core graph operations to provide an interpretive view of Pattern structures as graphs.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e166986-57e3-4352-9891-cee7bdcab4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2e166986-57e3-4352-9891-cee7bdcab4a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `GraphLens` to interpret `Pattern` as graphs with node, relationship, walk, navigation, and connectivity ops, plus initial tests and spec checklist updates.
> 
> - **Pattern**:
>   - **Graph Lens**: Implement `GraphLens` in `libs/pattern/src/Pattern/Graph.hs` with rich Haddock/module docs.
>   - **Node Ops**: `nodes`, `isNodeLens`.
>   - **Relationship Ops**: `isRelationship`, `relationships`, `source`, `target`, `reverseRel`.
>   - **Walk Ops**: `isWalk`, `walks`, `walkNodes`.
>   - **Navigation Ops**: `neighbors`, `incidentRels`, `degree`.
>   - **Analysis Ops**: `connectedComponents`, `bfs`, `findPath`.
> - **Tests**:
>   - Add foundational tests in `libs/pattern/tests/Spec/Pattern/GraphSpec.hs` for `GraphLens` construction and `nodes` behavior (including edge cases).
> - **Specs**:
>   - Update checklist statuses in `specs/023-graph-lens/tasks.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb2da7f1d95104bf0ad8ac0ba6eaeec8c846b72c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->