### PR TITLE
038 scope unification

### DIFF
--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -1,6 +1,6 @@
 # pattern-hs Development Guidelines
 
-Auto-generated from all feature plans. Last updated: 2025-11-04
+Auto-generated from all feature plans. Last updated: 2026-03-17
 
 ## Active Technologies
 - Haskell / GHC 9.12.2 (from cabal.project, matches feature 001) + `base` ^>=4.17.0.0, `containers` ^>=0.6 (from existing pattern.cabal) (002-basic-pattern-type)

--- a/.cursor/rules/specify-rules.mdc
+++ b/.cursor/rules/specify-rules.mdc
@@ -42,6 +42,8 @@ Auto-generated from all feature plans. Last updated: 2025-11-04
 - N/A — pure in-memory data structures (035-graph-query)
 - Haskell (GHC 9.12.2) + `pattern-hs` core (GraphClassifier, GraphQuery, PatternGraph) (036-graph-transform)
 - In-memory `PatternGraph` and `GraphView` representations (036-graph-transform)
+- Haskell (GHC 9.12.2) + `base`, `containers`, existing `pattern` modules (`Pattern.Core`, `Pattern.Graph`, `Pattern.Graph.GraphQuery`, `Pattern.Graph.Transform`) (038-scope-unification)
+- N/A - pure in-memory library behavior (038-scope-unification)
 
 - (001-pattern-data-structure)
 
@@ -61,9 +63,9 @@ tests/
 : Follow standard conventions
 
 ## Recent Changes
+- 038-scope-unification: Added Haskell (GHC 9.12.2) + `base`, `containers`, existing `pattern` modules (`Pattern.Core`, `Pattern.Graph`, `Pattern.Graph.GraphQuery`, `Pattern.Graph.Transform`)
 - 036-graph-transform: Added Haskell (GHC 9.12.2) + `pattern-hs` core (GraphClassifier, GraphQuery, PatternGraph)
 - 033-pattern-graph: Added Haskell (GHC 9.12.2 per CLAUDE.md; base >=4.17.0.0 from pattern.cabal) + pattern (Pattern.Core, Pattern.Reconcile), subject, containers, hashable, unordered-containers (from libs/pattern)
-- 032-gram-annotation-syntax: Added Haskell (GHC 9.12.2) + megaparsec (parsing), hspec (testing)
 
 
 <!-- MANUAL ADDITIONS START -->

--- a/docs/reference/PORTING-GUIDE.md
+++ b/docs/reference/PORTING-GUIDE.md
@@ -7,6 +7,24 @@
 
 This guide provides a recommended implementation order for porting the pattern-hs libraries to other languages. The order is designed to minimize dependencies and build a solid foundation before adding serialization capabilities.
 
+## Scope Abstraction Mapping
+
+The structure-aware fold APIs now use a three-part correspondence that ports should preserve semantically, even if the host language uses different syntax:
+
+| Haskell | Meaning | Typical port shape |
+|---------|---------|--------------------|
+| `ScopeQuery` typeclass | Generic scope behavior | Trait / protocol / interface |
+| `ScopeDict i v` | First-class stored scope value | Concrete object / struct / class |
+| `toScopeDict` | Reify a polymorphic provider into a value | Adapter constructor |
+
+Recommended mapping:
+
+- Rust: trait + concrete struct, using trait bounds in the fast path and boxed trait objects only at dynamic boundaries
+- TypeScript: interface + object literal/class implementing the interface
+- Python: protocol-like duck typing + concrete helper object when a stored value is needed
+
+For tree folds, `para` should remain a wrapper over the generic fold with a subtree-only scope. For graph folds, keep the graph scheduler and result shape stable, but derive generic scope answers from the enclosing graph snapshot.
+
 ## Implementation Phases
 
 ### Phase 1: Pattern Library (Foundation)
@@ -41,9 +59,11 @@ The Pattern library is the foundation. All other libraries depend on it.
    - `Ord`, `Semigroup`, `Monoid`, `Hashable`, `Applicative`, `Comonad`
    - See: `docs/reference/features/typeclass-instances.md`
 
-6. **Paramorphism** (structure-aware folding)
-   - `para :: (Pattern v -> [r] -> r) -> Pattern v -> r`
-   - Enables structure-aware aggregations
+6. **Unified Structure-Aware Folding**
+   - `ScopeQuery`
+   - `ScopeDict`
+   - `paraWithScope`
+   - `para` as the subtree-scoped wrapper
    - See: `docs/reference/features/paramorphism.md` and section below
 
 7. **Graph Lens** (optional but recommended)
@@ -389,11 +409,30 @@ See `docs/reference/IMPLEMENTATION.md#testing` for patterns.
 
 ### Overview
 
-Paramorphism enables structure-aware folding over patterns. Unlike `Foldable` (which only provides values), paramorphism gives your folding function access to the full pattern structure at each position.
-
-### Core Function Signature
+Paramorphism now has an explicit scope-aware core:
 
 ```haskell
+paraWithScope
+  :: ScopeQuery q v
+  => q v
+  -> (q v -> Pattern v -> [r] -> r)
+  -> Pattern v
+  -> r
+```
+
+`para` is the backward-compatible wrapper:
+
+```haskell
+para :: (Pattern v -> [r] -> r) -> Pattern v -> r
+para f p = paraWithScope (trivialScope p) (\_ pat rs -> f pat rs) p
+```
+
+Ports should preserve that relationship instead of implementing two unrelated folds.
+
+### Core Function Signatures
+
+```haskell
+paraWithScope :: ScopeQuery q v => q v -> (q v -> Pattern v -> [r] -> r) -> Pattern v -> r
 para :: (Pattern v -> [r] -> r) -> Pattern v -> r
 ```
 
@@ -407,16 +446,16 @@ para :: (Pattern v -> [r] -> r) -> Pattern v -> r
 
 ### Implementation Pattern
 
-The standard paramorphism pattern for recursive tree structures:
+The standard scope-aware pattern for recursive tree structures:
 
 ```haskell
-para f (Pattern v els) = 
-  f (Pattern v els) (map (para f) els)
+paraWithScope scope f (Pattern v els) =
+  f scope (Pattern v els) (map (paraWithScope scope f) els)
 ```
 
 **Breakdown**:
-1. Recursively compute results for all children using `para f`
-2. Apply folding function `f` to: (1) current pattern subtree, (2) list of child results
+1. Recursively compute results for all children using the same fixed scope
+2. Apply folding function `f` to: (1) scope, (2) current pattern subtree, (3) list of child results
 3. Return aggregated result
 
 ### Language-Specific Implementations

--- a/docs/reference/features/para-graph.md
+++ b/docs/reference/features/para-graph.md
@@ -5,7 +5,16 @@
 
 ## Overview
 
-`paraGraph` is the graph-level counterpart to `para` (paramorphism on `Pattern`). Where `para` recurses through a single pattern's tree structure, `paraGraph` folds across an entire `GraphView` — a flat collection of classified graph elements — in the correct containment order.
+`paraGraph` is now the graph-scoped wrapper in the same unified scope model that also powers `para`.
+
+Where `para` uses `TrivialScope` over one subtree, `paraGraph` keeps graph scheduling unchanged and derives generic scope answers from the whole `GraphView` snapshot. That graph adapter remains internal; the public API of `paraGraph` is unchanged.
+
+The key distinction is now explicit:
+
+- `para` folds one recursive tree with subtree-only scope
+- `paraGraph` folds one `GraphView` snapshot with graph-wide scope
+
+In both cases, the fold step is still driven by already-computed direct child results.
 
 The key challenge: a `GraphView` is a flat list, not a tree. `topoShapeSort` establishes the right processing order before the fold begins, so that every element is processed only after all elements it directly contains.
 
@@ -24,6 +33,23 @@ Layer 4: Other (GOther) — contain elements of any structure
 `paraGraph` processes layers 0 → 4 in order. Within layers 3 and 4, elements are additionally sorted by their dependency on each other: if annotation A annotates annotation B, B is processed before A.
 
 When your fold function `f` is called for element `p`, the `subResults` list contains computed results for every direct sub-element of `p` that has already been processed — which, in the absence of cycles, is all of them.
+
+## Unified Scope Relationship
+
+Graph folds now expose generic scope answers through `scopeDictFromGraphView`:
+
+```haskell
+scopeDictFromGraphView :: GraphValue v => GraphView extra v -> ScopeDict (Id v) v
+```
+
+This gives higher-order helpers access to:
+
+- `allElements` across the full classified `GraphView`
+- identity lookup bounded to that snapshot
+- direct containers across relationships, walks, annotations, and `GOther`
+- sibling derivation from those direct containers
+
+`paraGraph` itself still passes `GraphQuery v` to the user algebra so existing call sites do not change.
 
 ## Function Reference
 
@@ -196,6 +222,7 @@ An annotation that contains itself in `elements` creates a 1-element cycle. It w
 | | `para` | `paraGraph` |
 |-|--------|------------|
 | Input | Single `Pattern v` | `GraphView extra v` (flat collection) |
+| Scope boundary | `TrivialScope` over one subtree | Internal `GraphView`-backed scope over one snapshot |
 | Structure | Recursive tree descent | `topoShapeSort` then linear fold |
 | Order | Bottom-up by tree depth | Bottom-up by shape class + within-bucket deps |
 | Sub-results | Always complete (all children) | Best-effort (may be empty for cycle members) |

--- a/docs/reference/features/paramorphism.md
+++ b/docs/reference/features/paramorphism.md
@@ -5,7 +5,63 @@
 
 ## Overview
 
-Paramorphism enables structure-aware folding over patterns. Unlike `Foldable` (which only provides values), paramorphism gives your folding function access to the full pattern structure at each position, enabling sophisticated aggregations that consider depth, element count, and nesting level.
+Paramorphism now sits inside a broader unified scope model:
+
+- `ScopeQuery` describes what is visible during a structure-aware operation
+- `paraWithScope` is the canonical fold primitive
+- `TrivialScope` is the subtree-only scope used to preserve classic `para`
+- `ScopeDict` is the first-class value form for passing scope behavior around as data
+
+For existing callers, nothing changes: `para` remains the same API and the same behavior. Internally it is now derived as:
+
+```haskell
+para f p = paraWithScope (trivialScope p) (\_ pat rs -> f pat rs) p
+```
+
+This keeps the fold bottom-up and child-order-preserving while making the scope boundary explicit.
+
+## Unified Scope Model
+
+### `ScopeQuery`
+
+`ScopeQuery` answers four generic questions for the current scope:
+
+- direct containers of an element
+- siblings within those direct containers
+- lookup by scope identity
+- full enumeration of in-scope elements
+
+Tree-only scopes and graph-backed scopes can answer these questions differently, but folds can now talk to both through the same interface.
+
+### `paraWithScope`
+
+```haskell
+paraWithScope
+  :: ScopeQuery q v
+  => q v
+  -> (q v -> Pattern v -> [r] -> r)
+  -> Pattern v
+  -> r
+```
+
+The fold algebra receives:
+
+- the fixed scope value
+- the current pattern node
+- already-computed direct child results in `elements` order
+
+### `TrivialScope`
+
+`TrivialScope` keeps `para` backward-compatible by exposing only subtree information. It intentionally returns:
+
+- `containers = []`
+- `siblings = []`
+
+Its identity lookup is scope-local, using zero-based preorder positions within `allElements`.
+
+### `ScopeDict`
+
+`ScopeDict` is the value-form equivalent of `ScopeQuery`. Use it when a helper needs stored scope behavior instead of a polymorphic scope provider.
 
 ## Function Reference
 
@@ -15,7 +71,7 @@ Paramorphism enables structure-aware folding over patterns. Unlike `Foldable` (w
 para :: (Pattern v -> [r] -> r) -> Pattern v -> r
 ```
 
-**Description**: Paramorphism function that enables structure-aware folding over patterns. The folding function receives both the current pattern subtree and recursively computed results from children.
+**Description**: Backward-compatible wrapper over `paraWithScope` and `TrivialScope`. The folding function receives the current pattern subtree and recursively computed child results exactly as before.
 
 **Parameters**:
 - `f :: Pattern v -> [r] -> r`: Folding function that receives:
@@ -40,9 +96,16 @@ depthWeightedSum = para (\pat rs -> value pat * depth pat + sum rs) p
 
 ## Type Signatures
 
-### Core Function
+### Core Functions
 
 ```haskell
+paraWithScope
+  :: ScopeQuery q v
+  => q v
+  -> (q v -> Pattern v -> [r] -> r)
+  -> Pattern v
+  -> r
+
 para :: (Pattern v -> [r] -> r) -> Pattern v -> r
 ```
 
@@ -148,9 +211,11 @@ para (\p rs -> value p * depth p + sum rs) pattern  -- Aggregates, returns resul
 ### Standard Pattern
 
 ```haskell
-para :: (Pattern v -> [r] -> r) -> Pattern v -> r
-para f (Pattern v els) = 
-  f (Pattern v els) (map (para f) els)
+paraWithScope scope f (Pattern v els) =
+  f scope (Pattern v els) (map (paraWithScope scope f) els)
+
+para f p =
+  paraWithScope (trivialScope p) (\_ pat rs -> f pat rs) p
 ```
 
 **Breakdown**:
@@ -243,6 +308,7 @@ para (\p rs -> value p + sum rs) nested
 
 ## See Also
 
+- [paraGraph Reference](./para-graph.md) - Graph-scoped wrapper over the same scope model
 - [User Guide: Advanced Morphisms](../../guide/06-advanced-morphisms.md) - Intuitive explanation and examples
 - [Porting Guide: Paramorphism Implementation](../../PORTING-GUIDE.md#paramorphism-implementation) - How to implement in other languages
 - [Typeclass Instances](typeclass-instances.md) - Relationship to `Foldable` and `Comonad`

--- a/libs/pattern/src/Pattern.hs
+++ b/libs/pattern/src/Pattern.hs
@@ -10,7 +10,8 @@
 -- The Pattern library is organized into several modules:
 --
 -- * @Pattern.Core@ - Core Pattern data type, construction functions, query functions,
---   predicate functions, and typeclass instances (Functor, Applicative, Comonad, etc.)
+--   predicate functions, the unified scope abstractions ('ScopeQuery', 'TrivialScope',
+--   'ScopeDict'), and typeclass instances (Functor, Applicative, Comonad, etc.)
 -- * @Pattern.Graph@ - Low-level graph structural operations (GraphLens, 'fromGraphLens', nodes,
 --   relationships, incidentRels, etc.) and 'GraphView' constructor 'toGraphView'.
 -- * @Pattern.Graph.GraphQuery@ - Portable graph query interface ('GraphQuery', 'TraversalWeight',
@@ -19,7 +20,8 @@
 -- * @Pattern.Graph.Algorithms@ - Graph algorithms operating on 'GraphQuery' (bfs, dfs,
 --   shortestPath, connectedComponents, etc.)
 -- * @Pattern.Graph.Transform@ - Bulk graph transformations: 'unfoldGraph', 'mapGraph',
---   'mapAllGraph', 'filterGraph', 'foldGraph', 'mapWithContext', 'paraGraph', 'paraGraphFixed'
+--   'mapAllGraph', 'filterGraph', 'foldGraph', 'mapWithContext', the graph-scope
+--   reifier 'scopeDictFromGraphView', 'paraGraph', and 'paraGraphFixed'
 -- * @Pattern.PatternGraph@ - Typed graph container with O(log n) lookups; 'fromPatternGraph',
 --   'materialize', 'toGraphView'
 -- * @Pattern.Reconcile@ - Pattern reconciliation for normalizing duplicate identities

--- a/libs/pattern/src/Pattern/Core.hs
+++ b/libs/pattern/src/Pattern/Core.hs
@@ -1,4 +1,7 @@
 {-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
 module Pattern.Core
   ( -- * Pattern Type
     Pattern(..)
@@ -30,6 +33,12 @@ module Pattern.Core
   , sizeAt
   , indicesAt
     -- * Paramorphism Functions
+  , ScopeQuery(..)
+  , TrivialScope
+  , trivialScope
+  , ScopeDict(..)
+  , toScopeDict
+  , paraWithScope
   , para
     -- * Anamorphism Functions
   , unfold
@@ -1140,6 +1149,157 @@ indicesAt = go []
     go path (Pattern _ es) =
       Pattern path (zipWith (\i e -> go (path ++ [i]) e) [0..] es)
 
+-- | Generic contract for the scope available during a structure-aware fold.
+--
+-- Conceptually, a 'ScopeQuery' is the coalgebraic "context of visibility" for a
+-- fold: it answers what else can be observed while the fold is focused on one
+-- element. The fold target and the enclosing scope are intentionally distinct.
+--
+-- Invariants:
+--
+-- * 'containers' returns only /direct/ containers in the current scope.
+-- * 'siblings' returns only co-elements from those direct containers.
+-- * 'byIdentity' never widens the declared scope boundary.
+-- * 'allElements' enumerates exactly the current scope, no more and no less.
+--
+-- Different scope providers choose their own identity type through 'ScopeId'.
+-- Tree-only scopes can use a local, scope-relative identity, while graph-backed
+-- scopes can use their native graph element identifiers.
+--
+-- Example:
+--
+-- >>> let p = pattern "root" [point "a", point "b"]
+-- >>> let scope = trivialScope p
+-- >>> length (allElements scope)
+-- 3
+class ScopeQuery q v where
+  type ScopeId q v
+
+  -- | Direct containers of an element within the current scope.
+  containers :: q v -> Pattern v -> [Pattern v]
+
+  -- | Siblings of an element within the current scope.
+  siblings :: q v -> Pattern v -> [Pattern v]
+
+  -- | Lookup an element by the scope's identity type.
+  byIdentity :: q v -> ScopeId q v -> Maybe (Pattern v)
+
+  -- | Enumerate every element in scope.
+  allElements :: q v -> [Pattern v]
+
+-- | The subtree-only scope used by 'para'.
+--
+-- This is the smallest useful scope provider: it fixes visibility to one rooted
+-- subtree and intentionally omits parent and sibling context beyond that
+-- boundary. It preserves the original meaning of 'para'.
+--
+-- Invariants:
+--
+-- * 'containers' and 'siblings' are always @[]@.
+-- * 'allElements' is the subtree's preorder traversal.
+-- * 'byIdentity' uses zero-based preorder positions within that traversal.
+--
+-- Example:
+--
+-- >>> let p = pattern "root" [point "a", point "b"]
+-- >>> let scope = trivialScope p
+-- >>> fmap value (byIdentity scope 1)
+-- Just "a"
+newtype TrivialScope v = TrivialScope (Pattern v)
+
+-- | Construct the subtree-only scope used by 'para'.
+--
+-- The resulting scope remains fixed for the entire fold.
+trivialScope :: Pattern v -> TrivialScope v
+trivialScope = TrivialScope
+
+instance ScopeQuery TrivialScope v where
+  type ScopeId TrivialScope v = Int
+
+  containers _ _ = []
+  siblings _ _ = []
+  byIdentity (TrivialScope p) = subtreeElementAt p
+  allElements (TrivialScope p) = subtreeElements p
+
+-- | First-class value form of a scope provider.
+--
+-- 'ScopeDict' is the value-level analogue of the 'ScopeQuery' typeclass. It is
+-- useful when scope behavior needs to be stored, passed to non-polymorphic
+-- helpers, or reified for dynamic composition.
+--
+-- Example:
+--
+-- >>> let p = pattern "root" [point "a"]
+-- >>> let dict = toScopeDict (trivialScope p)
+-- >>> length (allElements dict)
+-- 2
+data ScopeDict i v = ScopeDict
+  { dictContainers  :: Pattern v -> [Pattern v]
+  , dictSiblings    :: Pattern v -> [Pattern v]
+  , dictByIdentity  :: i -> Maybe (Pattern v)
+  , dictAllElements :: [Pattern v]
+  }
+
+instance ScopeQuery (ScopeDict i) v where
+  type ScopeId (ScopeDict i) v = i
+
+  containers = dictContainers
+  siblings = dictSiblings
+  byIdentity = dictByIdentity
+  allElements = dictAllElements
+
+-- | Reify any scope provider into its first-class dictionary form.
+--
+-- This preserves the provider's observable generic scope answers.
+toScopeDict :: ScopeQuery q v => q v -> ScopeDict (ScopeId q v) v
+toScopeDict q = ScopeDict
+  { dictContainers = containers q
+  , dictSiblings = siblings q
+  , dictByIdentity = byIdentity q
+  , dictAllElements = allElements q
+  }
+
+-- | Enumerate a subtree in preorder.
+subtreeElements :: Pattern v -> [Pattern v]
+subtreeElements p@(Pattern _ es) = p : concatMap subtreeElements es
+
+-- | Lookup a subtree element by its zero-based preorder position.
+subtreeElementAt :: Pattern v -> Int -> Maybe (Pattern v)
+subtreeElementAt p i
+  | i < 0 = Nothing
+  | otherwise = safeIndex i (subtreeElements p)
+  where
+    safeIndex n xs = case drop n xs of
+      y:_ -> Just y
+      [] -> Nothing
+
+-- | Structure-aware fold with an explicit, fixed scope.
+--
+-- Categorically, this is the scope-aware paramorphism for 'Pattern': each step
+-- receives the current node, the already-computed direct child results, and the
+-- same enclosing scope value for the duration of the fold.
+--
+-- Invariants:
+--
+-- * Child results are computed bottom-up.
+-- * Child results preserve 'elements' order.
+-- * The supplied scope is not recomputed while descending.
+--
+-- Example:
+--
+-- >>> let p = pattern 10 [point 5, point 3]
+-- >>> paraWithScope (trivialScope p) (\_ pat rs -> value pat + sum rs) p
+-- 18
+paraWithScope
+  :: ScopeQuery q v
+  => q v
+  -> (q v -> Pattern v -> [r] -> r)
+  -> Pattern v
+  -> r
+paraWithScope scope f = go
+  where
+    go pat@(Pattern _ es) = f scope pat (map go es)
+
 -- | Paramorphism: structure-aware folding over patterns.
 --
 -- Paramorphism enables folding over pattern structures while providing access
@@ -1188,8 +1348,7 @@ indicesAt = go []
 --
 -- @since 0.1.0
 para :: (Pattern v -> [r] -> r) -> Pattern v -> r
-para f (Pattern v els) = 
-  f (Pattern v els) (map (para f) els)
+para f p = paraWithScope (trivialScope p) (\_ pat rs -> f pat rs) p
 
 -- | Anamorphism: recursively unfold a seed value into a 'Pattern'.
 --

--- a/libs/pattern/src/Pattern/Graph/Transform.hs
+++ b/libs/pattern/src/Pattern/Graph/Transform.hs
@@ -235,6 +235,8 @@ mapWithContext _classifier f view@(GraphView q elems) =
 -- * 'allElements' covers every classified element in the 'GraphView'.
 -- * 'byIdentity' is bounded to that snapshot.
 -- * 'containers' and 'siblings' are derived from direct containment only.
+-- * Duplicate graph identities are rejected when reifying generic scope
+--   answers, because 'ScopeQuery' lookup is keyed only by 'Id v'.
 --
 -- Example:
 --
@@ -334,11 +336,15 @@ graphViewScope (GraphView q taggedElems) = GraphViewScope
   }
   where
     elems = map snd taggedElems
-    index = Map.fromList
-      [ (identify (value p), p)
-      | p <- elems
-      ]
+    index = foldl' insertUniqueElement Map.empty elems
     containerIndex = foldl' indexContainer Map.empty elems
+
+    insertUniqueElement acc p =
+      let pid = identify (value p)
+      in case Map.lookup pid acc of
+           Nothing -> Map.insert pid p acc
+           Just _ ->
+             error "scopeDictFromGraphView: duplicate element identity in GraphView"
 
     indexContainer acc container =
       foldl' (insertContainer container) acc (elements container)
@@ -501,8 +507,7 @@ paraGraphWithSeed
 paraGraphWithSeed f view seed =
   foldl' processElem seed (topoShapeSort taggedElems)
   where
-    scope = graphViewScope view
-    q = gvsQuery scope
+    q = viewQuery view
     taggedElems = viewElements view
 
     processElem acc (_, p) =

--- a/libs/pattern/src/Pattern/Graph/Transform.hs
+++ b/libs/pattern/src/Pattern/Graph/Transform.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleContexts #-}  -- Reconcile.HasIdentity v (Id v), Ord (Id v) in signatures
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 -- | Graph transformation operations over 'GraphView'.
 --
@@ -37,6 +39,7 @@ module Pattern.Graph.Transform
     -- * Context-aware enrichment
   , mapWithContext
     -- * Iterative topology-aware algorithms
+  , scopeDictFromGraphView
   , paraGraph
   , paraGraphFixed
   ) where
@@ -45,7 +48,8 @@ import Data.List (foldl')
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (mapMaybe)
-import Pattern.Core (Pattern(..))
+import qualified Data.Set as Set
+import Pattern.Core (Pattern(..), ScopeDict, ScopeQuery(..), toScopeDict)
 import Pattern.Graph.Types (GraphView(..))
 import Pattern.Graph.GraphClassifier
   ( GraphClass(..), GraphClassifier(..), GraphValue(..) )
@@ -221,6 +225,24 @@ mapWithContext
 mapWithContext _classifier f view@(GraphView q elems) =
   view { viewElements = map (\(cls, p) -> (cls, f q p)) elems }
 
+-- | Reify the generic scope answers for a 'GraphView' snapshot.
+--
+-- This exposes the unified scope model without exporting the internal adapter
+-- type used to compute it.
+--
+-- Invariants:
+--
+-- * 'allElements' covers every classified element in the 'GraphView'.
+-- * 'byIdentity' is bounded to that snapshot.
+-- * 'containers' and 'siblings' are derived from direct containment only.
+--
+-- Example:
+--
+-- > let scope = scopeDictFromGraphView view
+-- > length (allElements scope)
+scopeDictFromGraphView :: GraphValue v => GraphView extra v -> ScopeDict (Id v) v
+scopeDictFromGraphView = toScopeDict . graphViewScope
+
 -- ============================================================================
 -- paraGraph
 -- ============================================================================
@@ -264,15 +286,68 @@ paraGraph
   => (GraphQuery v -> Pattern v -> [r] -> r)
   -> GraphView extra v
   -> Map (Id v) r
-paraGraph f (GraphView q elems) =
-  foldl' processElem Map.empty sortedElems
-  where
-    sortedElems = topoShapeSort elems
+paraGraph f view = paraGraphWithSeed f view Map.empty
 
-    processElem acc (_, p) =
-      let subResults = mapMaybe (\e -> Map.lookup (identify (value e)) acc) (elements p)
-          r = f q p subResults
-      in Map.insert (identify (value p)) r acc
+-- Internal adapter that exposes full GraphView scope to the generic scope layer
+-- without changing the public GraphQuery record shape.
+data GraphViewScope v = GraphViewScope
+  { gvsQuery      :: GraphQuery v
+  , gvsElements   :: [Pattern v]
+  , gvsIndex      :: Map (Id v) (Pattern v)
+  , gvsContainers :: Map (Id v) [Pattern v]
+  }
+
+instance GraphValue v => ScopeQuery GraphViewScope v where
+  type ScopeId GraphViewScope v = Id v
+
+  containers scope p =
+    Map.findWithDefault [] (identify (value p)) (gvsContainers scope)
+
+  siblings scope p =
+    dedupeById
+      [ sibling
+      | container <- containers scope p
+      , child <- elements container
+      , let childId = identify (value child)
+      , childId /= identify (value p)
+      , Just sibling <- [Map.lookup childId (gvsIndex scope)]
+      ]
+
+  byIdentity scope i = Map.lookup i (gvsIndex scope)
+  allElements = gvsElements
+
+dedupeById :: GraphValue v => [Pattern v] -> [Pattern v]
+dedupeById = reverse . fst . foldl' step ([], Set.empty)
+  where
+    step (acc, seen) p =
+      let pid = identify (value p)
+      in if Set.member pid seen
+           then (acc, seen)
+           else (p : acc, Set.insert pid seen)
+
+graphViewScope :: GraphValue v => GraphView extra v -> GraphViewScope v
+graphViewScope (GraphView q taggedElems) = GraphViewScope
+  { gvsQuery = q
+  , gvsElements = elems
+  , gvsIndex = index
+  , gvsContainers = containerIndex
+  }
+  where
+    elems = map snd taggedElems
+    index = Map.fromList
+      [ (identify (value p), p)
+      | p <- elems
+      ]
+    containerIndex = foldl' indexContainer Map.empty elems
+
+    indexContainer acc container =
+      foldl' (insertContainer container) acc (elements container)
+
+    insertContainer container acc child =
+      let childId = identify (value child)
+      in if Map.member childId index
+           then Map.insertWith (++) childId [container] acc
+           else acc
 
 -- | Order graph elements for correct bottom-up processing in 'paraGraph'.
 --
@@ -423,9 +498,13 @@ paraGraphWithSeed
   -> GraphView extra v
   -> Map (Id v) r
   -> Map (Id v) r
-paraGraphWithSeed f (GraphView q elems) seed =
-  foldl' processElem seed (topoShapeSort elems)
+paraGraphWithSeed f view seed =
+  foldl' processElem seed (topoShapeSort taggedElems)
   where
+    scope = graphViewScope view
+    q = gvsQuery scope
+    taggedElems = viewElements view
+
     processElem acc (_, p) =
       let subResults = mapMaybe (\e -> Map.lookup (identify (value e)) acc) (elements p)
           r = f q p subResults

--- a/libs/pattern/tests/Spec/Pattern/CoreSpec.hs
+++ b/libs/pattern/tests/Spec/Pattern/CoreSpec.hs
@@ -1,3 +1,6 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
 -- | Unit tests for Pattern.Core module.
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# OPTIONS_GHC -fno-warn-type-defaults #-}
@@ -19,12 +22,27 @@ import Data.Semigroup (sconcat, stimes)
 import qualified Data.Set as Set
 import Test.Hspec
 import Control.Comonad (extract, extend, duplicate)
-import Pattern.Core (Pattern(..), pattern, point, fromList, toTuple, size, depth, values, anyValue, allValues, filterPatterns, findPattern, findAllPatterns, matches, contains, depthAt, sizeAt, indicesAt, para, unfold)
+import Pattern.Core (Pattern(..), ScopeQuery(..), pattern, point, fromList, toTuple, size, depth, values, anyValue, allValues, filterPatterns, findPattern, findAllPatterns, matches, contains, depthAt, sizeAt, indicesAt, trivialScope, toScopeDict, para, paraWithScope, unfold)
 import qualified Pattern.Core as PC
+import qualified Spec.Pattern.Properties as Props
 
 -- Custom type for testing
 data Person = Person { name :: String, age :: Maybe Int }
   deriving (Eq, Show)
+
+newtype FlatScope v = FlatScope [Pattern v]
+
+instance PC.ScopeQuery FlatScope v where
+  type ScopeId FlatScope v = Int
+
+  containers _ _ = []
+  siblings _ _ = []
+  byIdentity (FlatScope ps) i
+    | i < 0 = Nothing
+    | otherwise = case drop i ps of
+        p:_ -> Just p
+        [] -> Nothing
+  allElements (FlatScope ps) = ps
 
 spec :: Spec
 spec = do
@@ -4399,6 +4417,93 @@ spec = do
           extract (elements result !! 1) `shouldBe` ([1] :: [Int])  -- "b": [1]
           extract (elements (elements result !! 0) !! 0) `shouldBe` ([0, 0] :: [Int])  -- "x": [0, 0]
     
+    describe "Unified scope queries (038-scope-unification)" $ do
+
+      describe "TrivialScope compatibility (US1)" $ do
+
+        it "T007: containers and siblings return [] across subtree-only scope" $ do
+          let leaf = point "leaf"
+          let branch = pattern "branch" [leaf]
+          let root = pattern "root" [branch, point "sibling"]
+          let scope = trivialScope root
+
+          containers scope root `shouldBe` []
+          containers scope leaf `shouldBe` []
+          siblings scope root `shouldBe` []
+          siblings scope leaf `shouldBe` []
+
+        it "T008: paraWithScope preserves child-result order and para compatibility" $ do
+          let left = pattern "left" [point "leaf"]
+          let right = point "right"
+          let root = pattern "root" [left, right]
+          let scope = trivialScope root
+
+          paraWithScope scope (\_ pat rs -> (value pat, map fst rs)) root
+            `shouldBe` ("root", ["left", "right"])
+
+          paraWithScope scope (\_ pat rs -> value pat : concat rs) root
+            `shouldBe` para (\pat rs -> value pat : concat rs) root
+
+        it "T009: paraWithScope (trivialScope p) is observationally equivalent to para" $
+          Props.quickProperty $ \p ->
+            let scope = trivialScope (p :: Pattern Int)
+                algebra pat rs = value pat + sum rs
+            in paraWithScope scope (\_ pat rs -> algebra pat rs) p == para algebra p
+
+      describe "Custom provider extensibility (US2)" $ do
+
+        it "T013: paraWithScope works with a custom scope provider" $ do
+          let root = pattern 10 [point 5, point 3]
+          let scope = FlatScope [root, point 5, point 3]
+          let result = paraWithScope scope (\q pat rs -> length (allElements q) + value pat + sum rs) root
+
+          result `shouldBe` (27 :: Int)
+          fmap value (byIdentity scope 1) `shouldBe` Just 5
+
+      describe "ScopeDict equivalence (US3)" $ do
+
+        it "T018: toScopeDict preserves subtree scope answers" $ do
+          let root = pattern "root" [pattern "left" [point "leaf"], point "right"]
+          let scope = trivialScope root
+          let dict = toScopeDict scope
+          let ids = [0 .. length (allElements scope) - 1]
+
+          allElements dict `shouldBe` allElements scope
+          map (byIdentity dict) ids `shouldBe` map (byIdentity scope) ids
+          containers dict root `shouldBe` containers scope root
+          siblings dict root `shouldBe` siblings scope root
+
+        it "T019: toScopeDict preserves subtree scope behavior for representative patterns" $
+          Props.quickProperty $ \p ->
+            let scope = trivialScope (p :: Pattern Int)
+                dict = toScopeDict scope
+                elems = allElements scope
+                ids = [0 .. length elems - 1]
+                sameLocalAnswers e = containers dict e == containers scope e
+                  && siblings dict e == siblings scope e
+            in allElements dict == elems
+              && map (byIdentity dict) ids == map (byIdentity scope) ids
+              && all sameLocalAnswers elems
+
+        it "T021: reified scope values can be passed to higher-order helpers unchanged" $ do
+          let root = pattern "root" [pattern "left" [point "leaf"], point "right"]
+          let scope = trivialScope root
+          let dict = toScopeDict scope
+          let directSummary =
+                ( length (allElements scope)
+                , length (containers scope root)
+                , length (siblings scope root)
+                , fmap value (byIdentity scope (0 :: Int))
+                )
+          let dictSummary =
+                ( length (allElements dict)
+                , length (containers dict root)
+                , length (siblings dict root)
+                , fmap value (byIdentity dict (0 :: Int))
+                )
+
+          dictSummary `shouldBe` directSummary
+
     describe "Paramorphism (User Story 1)" $ do
       
       describe "Basic paramorphism operations" $ do

--- a/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
+++ b/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
@@ -1,6 +1,7 @@
 -- | Tests for Pattern.Graph.Transform module.
 module Spec.Pattern.Graph.TransformSpec where
 
+import Control.Exception (evaluate)
 import Test.Hspec
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -82,6 +83,16 @@ graphWithScopeBoundary =
     , mkOther "other" [mkNode "a", mkNode "c", mkNode "d"]
     ]
 
+graphWithDuplicateScopeIds :: PatternGraph () Subject
+graphWithDuplicateScopeIds =
+  PG.fromPatterns canonicalClassifier
+    [ mkNode "dup"
+    , mkNode "a"
+    , mkNode "b"
+    , mkNode "c"
+    , mkOther "dup" [mkNode "a", mkNode "b", mkNode "c"]
+    ]
+
 -- Count elements by class
 countByClass :: GraphClass () -> GraphView () Subject -> Int
 countByClass target view =
@@ -138,6 +149,11 @@ spec = do
           `shouldBe` map (sort . subjectIds . containers direct) sampleElements
         map (sort . subjectIds . siblings reified) sampleElements
           `shouldBe` map (sort . subjectIds . siblings direct) sampleElements
+
+      it "rejects duplicate graph identities when reifying generic graph scope" $ do
+        let view = toGraphView canonicalClassifier graphWithDuplicateScopeIds
+        evaluate (byIdentity (scopeDictFromGraphView view) (Symbol "dup"))
+          `shouldThrow` anyErrorCall
 
     -- -----------------------------------------------------------------------
     -- Phase 1 / T008: GraphView initialization

--- a/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
+++ b/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
@@ -4,7 +4,8 @@ module Spec.Pattern.Graph.TransformSpec where
 import Test.Hspec
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import Pattern.Core (Pattern(..), point)
+import Data.List (sort)
+import Pattern.Core (Pattern(..), ScopeQuery(..), point, toScopeDict)
 import qualified Pattern.Core as P
 import Pattern.Graph (GraphView(..))
 import Pattern.Graph.GraphClassifier
@@ -50,6 +51,12 @@ simpleGraph =
 mkWalk :: String -> [Pattern Subject] -> Pattern Subject
 mkWalk walkId rels = Pattern (mkSubject walkId) rels
 
+mkAnnotation :: String -> Pattern Subject -> Pattern Subject
+mkAnnotation annotId inner = Pattern (mkSubject annotId) [inner]
+
+mkOther :: String -> [Pattern Subject] -> Pattern Subject
+mkOther otherId parts = Pattern (mkSubject otherId) parts
+
 graphWithWalk :: PatternGraph () Subject
 graphWithWalk =
   PG.fromPatterns canonicalClassifier
@@ -61,10 +68,27 @@ graphWithWalk =
     , mkWalk "path1" [mkRel "ab" "a" "b", mkRel "bc" "b" "c"]
     ]
 
+graphWithScopeBoundary :: PatternGraph () Subject
+graphWithScopeBoundary =
+  PG.fromPatterns canonicalClassifier
+    [ mkNode "a"
+    , mkNode "b"
+    , mkNode "c"
+    , mkNode "d"
+    , mkRel "ab" "a" "b"
+    , mkRel "bc" "b" "c"
+    , mkWalk "path1" [mkRel "ab" "a" "b", mkRel "bc" "b" "c"]
+    , mkAnnotation "annot-ab" (mkRel "ab" "a" "b")
+    , mkOther "other" [mkNode "a", mkNode "c", mkNode "d"]
+    ]
+
 -- Count elements by class
 countByClass :: GraphClass () -> GraphView () Subject -> Int
 countByClass target view =
   length [ () | (cls, _) <- viewElements view, cls == target ]
+
+subjectIds :: [Pattern Subject] -> [Symbol]
+subjectIds = map (Subj.identity . value)
 
 -- ---------------------------------------------------------------------------
 -- Spec
@@ -73,6 +97,47 @@ countByClass target view =
 spec :: Spec
 spec = do
   describe "Pattern.Graph.Transform" $ do
+
+    describe "graph-backed scope answers (US2/US3)" $ do
+
+      it "T014: scopeDictFromGraphView covers all graph-scoped elements and lookups" $ do
+        let view = toGraphView canonicalClassifier graphWithScopeBoundary
+        let scope = scopeDictFromGraphView view
+
+        length (allElements scope) `shouldBe` length (viewElements view)
+        fmap (Subj.identity . value) (byIdentity scope (Symbol "path1")) `shouldBe` Just (Symbol "path1")
+        fmap (Subj.identity . value) (byIdentity scope (Symbol "annot-ab")) `shouldBe` Just (Symbol "annot-ab")
+        fmap (Subj.identity . value) (byIdentity scope (Symbol "other")) `shouldBe` Just (Symbol "other")
+
+      it "T014b: graph scope answers direct containers and siblings within one GraphView" $ do
+        let view = toGraphView canonicalClassifier graphWithScopeBoundary
+        let scope = scopeDictFromGraphView view
+        let Just relAb = byIdentity scope (Symbol "ab")
+        let Just nodeA = byIdentity scope (Symbol "a")
+
+        sort (subjectIds (containers scope relAb)) `shouldBe` sort [Symbol "path1", Symbol "annot-ab"]
+        sort (subjectIds (siblings scope relAb)) `shouldBe` sort [Symbol "bc"]
+        sort (subjectIds (siblings scope nodeA)) `shouldBe` sort [Symbol "b", Symbol "c", Symbol "d"]
+
+      it "T020: reifying a graph-backed scope value preserves generic scope answers" $ do
+        let view = toGraphView canonicalClassifier graphWithScopeBoundary
+        let direct = scopeDictFromGraphView view
+        let reified = toScopeDict direct
+        let ids = [Symbol "a", Symbol "ab", Symbol "path1", Symbol "annot-ab", Symbol "other"]
+        let elementsInScope = allElements direct
+        let sampleElements =
+              [ p
+              | symbol <- ids
+              , Just p <- [byIdentity direct symbol]
+              ]
+
+        allElements reified `shouldBe` elementsInScope
+        map (fmap (Subj.identity . value) . byIdentity reified) ids
+          `shouldBe` map (fmap (Subj.identity . value) . byIdentity direct) ids
+        map (sort . subjectIds . containers reified) sampleElements
+          `shouldBe` map (sort . subjectIds . containers direct) sampleElements
+        map (sort . subjectIds . siblings reified) sampleElements
+          `shouldBe` map (sort . subjectIds . siblings direct) sampleElements
 
     -- -----------------------------------------------------------------------
     -- Phase 1 / T008: GraphView initialization
@@ -413,6 +478,16 @@ spec = do
     -- -----------------------------------------------------------------------
     describe "paraGraph (US4)" $ do
 
+      it "T010: paraGraph preserves wrapper behavior on graph-scoped inputs" $ do
+        let view = toGraphView canonicalClassifier graphWithWalk
+        let score _ p subResults = length (elements p) + sum (subResults :: [Int])
+        let result = paraGraph score view
+
+        Map.lookup (identify (mkSubject "a")) result `shouldBe` Just 0
+        Map.lookup (identify (mkSubject "ab")) result `shouldBe` Just 2
+        Map.lookup (identify (mkSubject "bc")) result `shouldBe` Just 2
+        Map.lookup (identify (mkSubject "path1")) result `shouldBe` Just 6
+
       it "produces a result for every element" $ do
         let view = toGraphView canonicalClassifier simpleGraph
         let countChildren _ _ subResults = length subResults
@@ -512,6 +587,14 @@ spec = do
     -- US4 / T023: paraGraphFixed convergence
     -- -----------------------------------------------------------------------
     describe "paraGraphFixed (US4)" $ do
+
+      it "T010b: paraGraphFixed preserves stable wrapper results" $ do
+        let view = toGraphView canonicalClassifier graphWithWalk
+        let conv old new = old == new
+        let score _ p subResults = length (elements p) + sum (subResults :: [Int])
+        let result = paraGraphFixed conv score 0 view
+
+        Map.lookup (identify (mkSubject "path1")) result `shouldBe` Just 6
 
       it "converges to a stable result" $ do
         let view = toGraphView canonicalClassifier simpleGraph

--- a/proposals/scope-unification-proposal.md
+++ b/proposals/scope-unification-proposal.md
@@ -5,7 +5,7 @@
 **Depends on:** GraphQuery proposal (design only; `GraphQuery` record must be in scope)  
 **Part of:** `representation-map-proposal.md` (scope unification layer only)  
 **Followed by:** RepresentationMap proposal (depends on this proposal being implemented)  
-**Location:** `proposals/scope-unification.md` within the `pattern-hs` workspace
+**Location:** `proposals/scope-unification-proposal.md` within the `pattern-hs` workspace
 
 ---
 
@@ -66,19 +66,22 @@ Different containers provide different operations; richer containers extend simp
 -- Pattern.Core
 
 class ScopeQuery q v where
+  type ScopeId q v
+
   containers  :: q v -> Pattern v -> [Pattern v]
     -- ^ patterns that directly contain this element within the scope
   siblings    :: q v -> Pattern v -> [Pattern v]
     -- ^ co-elements of the same immediate parent within the scope
-  byIdentity  :: q v -> Id v -> Maybe (Pattern v)
+  byIdentity  :: q v -> ScopeId q v -> Maybe (Pattern v)
     -- ^ look up any element in scope by identity
   allElements :: q v -> [Pattern v]
     -- ^ enumerate all elements within the scope
 ```
 
 The type variable `q` is the scope query implementation. Different containers
-instantiate `q` differently: `TrivialScope` for immediate-children scope, `GraphQuery`
-for graph-classified scope, and any future scope the caller cares to define.
+instantiate `q` differently: `TrivialScope` for subtree scope, `GraphView`-backed
+scope dictionaries for graph-wide generic answers, and any future scope the caller
+cares to define.
 
 The caller is always responsible for constructing the scope. The scope is not inferred
 from the fold target — it is passed in explicitly.
@@ -97,23 +100,27 @@ trivialScope :: Pattern v -> TrivialScope v
 trivialScope = TrivialScope
 
 instance ScopeQuery TrivialScope v where
+  type ScopeId TrivialScope v = Int
+
   containers  _ _               = []
     -- no parent information available in trivial scope
   siblings    _ _               = []
     -- no sibling information available in trivial scope
-  byIdentity  (TrivialScope p) i = findInSubtree i p
-    -- search within the subtree only
+  byIdentity  (TrivialScope p) i = subtreeElementAt p i
+    -- preorder lookup within the subtree only
   allElements (TrivialScope p)   = subtreeElements p
     -- all elements reachable within the subtree
 ```
 
-`findInSubtree` and `subtreeElements` are straightforward recursive traversals over
+`subtreeElementAt` and `subtreeElements` are straightforward recursive traversals over
 `Pattern v`. Both should already exist or be trivial to add in `Pattern.Core`.
 
-### `GraphScope` — graph-topology-aware scope
+### Possible follow-on: `GraphScope`
 
-A subclass of `ScopeQuery` that adds operations meaningful only when the scoped
-patterns are graph-classified (i.e. satisfy `GNode`, `GRelationship`, etc.).
+A natural follow-on is a graph-topology-specific subclass of `ScopeQuery` that adds
+operations meaningful only when the scoped patterns are graph-classified
+(i.e. satisfy `GNode`, `GRelationship`, etc.). This PR does not implement that
+extension; it stops at the generic scope layer plus graph-wide scope reification.
 
 ```haskell
 -- Pattern.Graph
@@ -128,36 +135,33 @@ class ScopeQuery q v => GraphScope q v where
 ```
 
 `source`, `target`, and `incidents` are only meaningful on `GRelationship`- and
-`GNode`-kinded patterns. The constraint hierarchy mirrors this: code that needs graph
-topology requires `GraphScope q v`; code that needs only containment and lookup
-requires only `ScopeQuery q v`.
+`GNode`-kinded patterns. If added later, the constraint hierarchy would mirror this:
+code that needs graph topology would require `GraphScope q v`; code that needs only
+containment and lookup would continue to require only `ScopeQuery q v`.
 
-### `GraphQuery` gains instances
+### `GraphView` provides graph-wide generic scope answers
 
-The existing `GraphQuery v` record-of-functions gains `ScopeQuery` and `GraphScope`
-instances. The existing record fields become the implementations. **No fields are
-removed or renamed.**
+The existing `GraphQuery v` record remains unchanged. In the implemented design,
+`GraphQuery` alone is not sufficient to answer generic `ScopeQuery` operations such as
+`allElements` and graph-wide `byIdentity`, because it only exposes nodes,
+relationships, and graph-topology queries. Walks, annotations, and other classified
+elements live in `GraphView`.
+
+Instead, graph-wide generic scope answers are derived from a full `GraphView`
+snapshot via an internal `GraphViewScope` adapter and the exported
+`scopeDictFromGraphView` helper. This keeps `GraphQuery` additive-only while making
+the complete classified `GraphView` available to the generic scope layer.
 
 ```haskell
--- Pattern.Graph
+-- Pattern.Graph.Transform
 
-instance ScopeQuery GraphQuery v where
-  containers  q p = queryContainers q p
-  siblings    q p = concatMap elements (queryContainers q p)
-  byIdentity  q i = queryNodeById q i
-  allElements q   = queryNodes q ++ queryRelationships q
-
-instance GraphScope GraphQuery v where
-  source    = querySource
-  target    = queryTarget
-  incidents = queryIncidentRels
-  degree    = queryDegree
-  nodes     = queryNodes
-  rels      = queryRelationships
+scopeDictFromGraphView :: GraphValue v => GraphView extra v -> ScopeDict (Id v) v
 ```
 
-All existing code that passes `GraphQuery v` values around continues to work
-unchanged. These instances are additive declarations only.
+This design also makes an important invariant explicit: generic graph-wide
+`byIdentity` is well-defined only when `Id v` is unique across the classified
+`GraphView` snapshot. Duplicate identities should be rejected rather than silently
+collapsed.
 
 ### `ScopeDict` — the first-class value form
 
@@ -165,26 +169,28 @@ For situations where a `ScopeQuery` instance needs to be stored in a data struct
 passed to a non-polymorphic higher-order function, or constructed dynamically at
 runtime, a `ScopeDict` record is provided alongside the typeclass. The record is itself
 a `ScopeQuery` instance, and any instance can be reified into a `ScopeDict` via
-`toDict`.
+`toScopeDict`.
 
 ```haskell
 -- Pattern.Core
 
-data ScopeDict v = ScopeDict
+data ScopeDict i v = ScopeDict
   { dictContainers  :: Pattern v -> [Pattern v]
   , dictSiblings    :: Pattern v -> [Pattern v]
-  , dictByIdentity  :: Id v -> Maybe (Pattern v)
+  , dictByIdentity  :: i -> Maybe (Pattern v)
   , dictAllElements :: [Pattern v]
   }
 
-instance ScopeQuery ScopeDict v where
+instance ScopeQuery (ScopeDict i) v where
+  type ScopeId (ScopeDict i) v = i
+
   containers  d   = dictContainers d
   siblings    d   = dictSiblings d
   byIdentity  d   = dictByIdentity d
-  allElements d _ = dictAllElements d
+  allElements d   = dictAllElements d
 
-toDict :: ScopeQuery q v => q v -> ScopeDict v
-toDict q = ScopeDict
+toScopeDict :: ScopeQuery q v => q v -> ScopeDict (ScopeId q v) v
+toScopeDict q = ScopeDict
   { dictContainers  = containers q
   , dictSiblings    = siblings q
   , dictByIdentity  = byIdentity q
@@ -230,7 +236,7 @@ para f p = paraWithScope (trivialScope p) (\_ pat rs -> f pat rs) p
 `para` is unchanged at every call site. The `ScopeQuery` parameter is hidden behind
 `trivialScope`. Behavior is identical to the current implementation.
 
-### `paraGraph` redefined
+### `paraGraph` preserved as the graph-specific wrapper
 
 ```haskell
 -- Pattern.Graph
@@ -239,13 +245,14 @@ paraGraph
   :: (GraphQuery v -> Pattern v -> [r] -> r)
   -> GraphView extra v
   -> Map (Id v) r
-paraGraph f view =
-  paraWithScope (viewQuery view) f (viewRoot view)
+paraGraph f view = ...
 ```
 
-`paraGraph` is unchanged at every call site. The scope is now explicitly the
-`GraphQuery v` derived from the `GraphView`, which is what it always was implicitly.
-Behavior is identical to the current implementation.
+`paraGraph` is unchanged at every call site and still passes a `GraphQuery v` into the
+algebra, preserving the existing scheduling and cycle-softening semantics over
+`GraphView`. The unified generic scope layer is exposed separately via
+`scopeDictFromGraphView`; `paraGraph` itself remains a graph-specific wrapper because
+it folds over a classified `GraphView`, not a single rooted `Pattern`.
 
 ### Other derived operations
 
@@ -262,13 +269,12 @@ is confirmed.
 |---|---|---|
 | `ScopeQuery` typeclass | `Pattern.Core` | **New** |
 | `TrivialScope` + `trivialScope` | `Pattern.Core` | **New** |
-| `ScopeDict` + `toDict` | `Pattern.Core` | **New** |
+| `ScopeDict` + `toScopeDict` | `Pattern.Core` | **New** |
 | `paraWithScope` | `Pattern.Core` | **New** |
 | `para` | `Pattern.Core` | **Redefine** (no API change) |
-| `GraphScope` typeclass | `Pattern.Graph` | **New** |
-| `ScopeQuery GraphQuery` instance | `Pattern.Graph` | **New** |
-| `GraphScope GraphQuery` instance | `Pattern.Graph` | **New** |
-| `paraGraph` | `Pattern.Graph` | **Redefine** (no API change) |
+| `scopeDictFromGraphView` | `Pattern.Graph.Transform` | **New** |
+| Internal `GraphViewScope` adapter | `Pattern.Graph.Transform` | **New (internal)** |
+| `paraGraph` | `Pattern.Graph.Transform` | **Preserve wrapper** (no API change) |
 
 No existing definitions are removed. No existing call sites require changes.
 
@@ -276,19 +282,20 @@ No existing definitions are removed. No existing call sites require changes.
 
 ## Interface convention note
 
-This proposal introduces `ScopeQuery` and `GraphScope` as typeclasses rather than
-records-of-functions. This is a deliberate choice for new interfaces in `pattern-hs`
+This proposal introduces `ScopeQuery` as a typeclass rather than a
+record-of-functions, and sketches how follow-on interfaces like `GraphScope` would use
+the same convention. This is a deliberate choice for new interfaces in `pattern-hs`
 going forward, and the reasoning is documented here to be explicit.
 
 The existing `GraphQuery` and `GraphClassifier` records are **not** converted — that
-would be a breaking change with limited benefit. Instead they gain typeclass instances,
-which is purely additive.
+would be a breaking change with limited benefit. Instead, new generic scope behavior is
+reified from `GraphView` where the full classified element set is available.
 
 For new interfaces from this point forward:
 
 1. Define the interface as a typeclass
-2. Provide a `*Dict` record as the first-class value form, with a `toDict` reification
-3. Give existing records typeclass instances where they satisfy the interface
+2. Provide a `*Dict` record as the first-class value form, with a `toScopeDict` reification
+3. Reify existing records/snapshots into the new interface when they satisfy it without losing information
 4. Document the cross-language correspondence in the porting guide
 
 **Cross-language correspondence:**
@@ -297,7 +304,7 @@ For new interfaces from this point forward:
 |---|---|---|
 | Typeclass | Trait | Protocol / Interface |
 | `*Dict` record | Struct implementing trait | Concrete class |
-| `toDict` | `impl Trait for Struct` | `__init__` + protocol conformance |
+| `toScopeDict` | `impl Trait for Struct` | `__init__` + protocol conformance |
 | `&dyn ScopeQuery<V>` (at boundary) | `Box<dyn ScopeQuery<V>>` | WASM-exported object |
 
 The Rust port uses `&dyn ScopeQuery<V>` at FFI and dynamic-dispatch boundaries. Within
@@ -315,7 +322,7 @@ Confirm that `findInSubtree` and `subtreeElements` exist and are correct. Add th
 missing. These are simple recursive traversals; their correctness is a prerequisite for
 `TrivialScope`.
 
-### Step 2 — `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toDict`
+### Step 2 — `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toScopeDict`
 
 Add to `Pattern.Core`. No dependencies on other new definitions. Write unit tests
 for `TrivialScope`: `containers` and `siblings` return `[]`; `byIdentity` finds
@@ -327,10 +334,11 @@ Implement `paraWithScope`. Redefine `para` in terms of it. Run the existing `par
 test suite — all tests must pass without modification. This is the primary correctness
 check: if `para` is behaviorally identical before and after, the refactoring is sound.
 
-### Step 4 — `GraphScope`, instances in `Pattern.Graph`
+### Step 4 — graph-wide scope reification in `Pattern.Graph.Transform`
 
-Add `GraphScope` typeclass to `Pattern.Graph`. Add `ScopeQuery GraphQuery` and
-`GraphScope GraphQuery` instances. Redefine `paraGraph` in terms of `paraWithScope`.
+Add the internal `GraphViewScope` adapter and exported `scopeDictFromGraphView` helper
+to `Pattern.Graph.Transform`. Keep `GraphQuery(..)` unchanged, and preserve
+`paraGraph`/`paraGraphFixed` as wrappers over graph-specific scheduling.
 Run the existing `paraGraph` test suite — all tests must pass without modification.
 
 ### Step 5 — verify no regressions
@@ -364,11 +372,10 @@ This proposal deliberately excludes the following, which belong to later proposa
 
 The implementation is complete when:
 
-1. `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toDict`, and `paraWithScope` are
+1. `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toScopeDict`, and `paraWithScope` are
    present in `Pattern.Core` and exported.
-2. `GraphScope`, `ScopeQuery GraphQuery`, and `GraphScope GraphQuery` are present in
-   `Pattern.Graph` and exported.
-3. `para` and `paraGraph` are redefined as derived operations and pass their existing
+2. `scopeDictFromGraphView` is present in `Pattern.Graph.Transform` and exported.
+3. `para` and `paraGraph` preserve their existing call sites and pass their existing
    test suites without modification.
 4. The full `pattern-hs` test suite passes with no failures.
 5. No existing call sites required changes.
@@ -379,7 +386,7 @@ The implementation is complete when:
 
 - `representation-map-proposal.md` — the larger proposal this is extracted from;
   `RepresentationMap` depends on this proposal being implemented first
-- `proposals/graph-query.md` — `GraphQuery` record that gains `ScopeQuery` and
-  `GraphScope` instances here
+- `proposals/graph-query.md` — `GraphQuery` record used by `paraGraph`; generic
+  graph-wide scope answers are reified from `GraphView` rather than added here
 - `proposals/graph-transform.md` — the next proposal in sequence after this one is
   merged; `RepresentationMap` depends on both

--- a/proposals/scope-unification-proposal.md
+++ b/proposals/scope-unification-proposal.md
@@ -1,0 +1,385 @@
+# Proposal: Scope Unification — `ScopeQuery` and `paraWithScope`
+
+**Status:** Design — ready for Haskell prototype  
+**Date:** 2026-03-17  
+**Depends on:** GraphQuery proposal (design only; `GraphQuery` record must be in scope)  
+**Part of:** `representation-map-proposal.md` (scope unification layer only)  
+**Followed by:** RepresentationMap proposal (depends on this proposal being implemented)  
+**Location:** `proposals/scope-unification.md` within the `pattern-hs` workspace
+
+---
+
+## Summary
+
+Introduce `ScopeQuery` as a typeclass abstracting over *what is in scope* for a fold
+operation, and `paraWithScope` as the unified primitive fold that replaces `para` and
+`paraGraph` as derivable special cases.
+
+This is a purely additive refactoring. No existing API is removed or broken. No
+behavior changes. The goal is to reveal structure that is already implicit in
+`Pattern<V>`: that `para` and `paraGraph` are the same operation at different scope
+boundaries, and that the scope boundary is determined by a containing element, not by
+the query interface used to access it.
+
+This proposal is self-contained and does not depend on `GraphTransform`,
+`RepresentationMap`, or `pattern-equivalence`. It can be implemented, tested, and
+merged independently.
+
+---
+
+## Background: the current situation
+
+`pattern-hs` currently has two fold operations:
+
+- **`para`** — a paramorphism over `Pattern v`. Each node receives its own value and
+  the bottom-up results of its direct children. Scope is implicit: the fold sees only
+  the immediate subtree.
+
+- **`paraGraph`** — a fold over a `GraphView`. Each element receives a `GraphQuery v`
+  giving access to the full graph context: containers, neighbors, incident
+  relationships. Scope is the whole enclosing `GraphView`.
+
+These look like two different operations serving two different purposes. The insight
+behind this proposal is that they are the same operation at different scope boundaries.
+The difference is not "pattern vs. graph" — it is **which containing element defines
+the scope**. In `para`, scope is the current node's immediate children. In
+`paraGraph`, scope is the enclosing `GraphView` element.
+
+Making this explicit has two benefits:
+
+1. `para` and `paraGraph` can be redefined as derived operations, eliminating the
+   duplication in their implementations.
+2. New scope kinds — a gram document, a project corpus, a subgraph — can be introduced
+   without adding new fold primitives. Any element that can produce a `ScopeQuery`
+   value participates in the same fold.
+
+---
+
+## Design
+
+### `ScopeQuery` — the typeclass
+
+A `ScopeQuery` is a query interface into a scope defined by some containing element.
+Different containers provide different operations; richer containers extend simpler ones.
+
+```haskell
+-- Pattern.Core
+
+class ScopeQuery q v where
+  containers  :: q v -> Pattern v -> [Pattern v]
+    -- ^ patterns that directly contain this element within the scope
+  siblings    :: q v -> Pattern v -> [Pattern v]
+    -- ^ co-elements of the same immediate parent within the scope
+  byIdentity  :: q v -> Id v -> Maybe (Pattern v)
+    -- ^ look up any element in scope by identity
+  allElements :: q v -> [Pattern v]
+    -- ^ enumerate all elements within the scope
+```
+
+The type variable `q` is the scope query implementation. Different containers
+instantiate `q` differently: `TrivialScope` for immediate-children scope, `GraphQuery`
+for graph-classified scope, and any future scope the caller cares to define.
+
+The caller is always responsible for constructing the scope. The scope is not inferred
+from the fold target — it is passed in explicitly.
+
+### `TrivialScope` — the immediate-children scope
+
+The simplest `ScopeQuery` instance. Scope is defined by a single `Pattern v` and
+covers only that pattern's subtree. This is the scope appropriate for `para`.
+
+```haskell
+-- Pattern.Core
+
+newtype TrivialScope v = TrivialScope (Pattern v)
+
+trivialScope :: Pattern v -> TrivialScope v
+trivialScope = TrivialScope
+
+instance ScopeQuery TrivialScope v where
+  containers  _ _               = []
+    -- no parent information available in trivial scope
+  siblings    _ _               = []
+    -- no sibling information available in trivial scope
+  byIdentity  (TrivialScope p) i = findInSubtree i p
+    -- search within the subtree only
+  allElements (TrivialScope p)   = subtreeElements p
+    -- all elements reachable within the subtree
+```
+
+`findInSubtree` and `subtreeElements` are straightforward recursive traversals over
+`Pattern v`. Both should already exist or be trivial to add in `Pattern.Core`.
+
+### `GraphScope` — graph-topology-aware scope
+
+A subclass of `ScopeQuery` that adds operations meaningful only when the scoped
+patterns are graph-classified (i.e. satisfy `GNode`, `GRelationship`, etc.).
+
+```haskell
+-- Pattern.Graph
+
+class ScopeQuery q v => GraphScope q v where
+  source    :: q v -> Pattern v -> Maybe (Pattern v)
+  target    :: q v -> Pattern v -> Maybe (Pattern v)
+  incidents :: q v -> Pattern v -> [Pattern v]
+  degree    :: q v -> Pattern v -> Int
+  nodes     :: q v -> [Pattern v]
+  rels      :: q v -> [Pattern v]
+```
+
+`source`, `target`, and `incidents` are only meaningful on `GRelationship`- and
+`GNode`-kinded patterns. The constraint hierarchy mirrors this: code that needs graph
+topology requires `GraphScope q v`; code that needs only containment and lookup
+requires only `ScopeQuery q v`.
+
+### `GraphQuery` gains instances
+
+The existing `GraphQuery v` record-of-functions gains `ScopeQuery` and `GraphScope`
+instances. The existing record fields become the implementations. **No fields are
+removed or renamed.**
+
+```haskell
+-- Pattern.Graph
+
+instance ScopeQuery GraphQuery v where
+  containers  q p = queryContainers q p
+  siblings    q p = concatMap elements (queryContainers q p)
+  byIdentity  q i = queryNodeById q i
+  allElements q   = queryNodes q ++ queryRelationships q
+
+instance GraphScope GraphQuery v where
+  source    = querySource
+  target    = queryTarget
+  incidents = queryIncidentRels
+  degree    = queryDegree
+  nodes     = queryNodes
+  rels      = queryRelationships
+```
+
+All existing code that passes `GraphQuery v` values around continues to work
+unchanged. These instances are additive declarations only.
+
+### `ScopeDict` — the first-class value form
+
+For situations where a `ScopeQuery` instance needs to be stored in a data structure,
+passed to a non-polymorphic higher-order function, or constructed dynamically at
+runtime, a `ScopeDict` record is provided alongside the typeclass. The record is itself
+a `ScopeQuery` instance, and any instance can be reified into a `ScopeDict` via
+`toDict`.
+
+```haskell
+-- Pattern.Core
+
+data ScopeDict v = ScopeDict
+  { dictContainers  :: Pattern v -> [Pattern v]
+  , dictSiblings    :: Pattern v -> [Pattern v]
+  , dictByIdentity  :: Id v -> Maybe (Pattern v)
+  , dictAllElements :: [Pattern v]
+  }
+
+instance ScopeQuery ScopeDict v where
+  containers  d   = dictContainers d
+  siblings    d   = dictSiblings d
+  byIdentity  d   = dictByIdentity d
+  allElements d _ = dictAllElements d
+
+toDict :: ScopeQuery q v => q v -> ScopeDict v
+toDict q = ScopeDict
+  { dictContainers  = containers q
+  , dictSiblings    = siblings q
+  , dictByIdentity  = byIdentity q
+  , dictAllElements = allElements q
+  }
+```
+
+`ScopeDict` is an escape hatch, not the primary interface. Prefer the typeclass form
+in function signatures. Use `ScopeDict` when a first-class value is genuinely needed.
+
+---
+
+## The unified primitive: `paraWithScope`
+
+```haskell
+-- Pattern.Core
+
+paraWithScope
+  :: ScopeQuery q v
+  => q v                               -- scope: the containing element's query interface
+  -> (q v -> Pattern v -> [r] -> r)   -- algebra: scope, current node, child results
+  -> Pattern v                         -- root pattern to fold over
+  -> r
+```
+
+The algebra receives three arguments:
+- the scope query, for lookups and context
+- the current pattern node
+- the bottom-up results of the current node's direct children
+
+The fold is bottom-up. The scope is fixed for the duration of the fold — it is the
+scope of the containing element, not of each node as the fold descends.
+
+### `para` redefined
+
+```haskell
+-- Pattern.Core
+
+para :: (Pattern v -> [r] -> r) -> Pattern v -> r
+para f p = paraWithScope (trivialScope p) (\_ pat rs -> f pat rs) p
+```
+
+`para` is unchanged at every call site. The `ScopeQuery` parameter is hidden behind
+`trivialScope`. Behavior is identical to the current implementation.
+
+### `paraGraph` redefined
+
+```haskell
+-- Pattern.Graph
+
+paraGraph
+  :: (GraphQuery v -> Pattern v -> [r] -> r)
+  -> GraphView extra v
+  -> Map (Id v) r
+paraGraph f view =
+  paraWithScope (viewQuery view) f (viewRoot view)
+```
+
+`paraGraph` is unchanged at every call site. The scope is now explicitly the
+`GraphQuery v` derived from the `GraphView`, which is what it always was implicitly.
+Behavior is identical to the current implementation.
+
+### Other derived operations
+
+Any other operations currently duplicated between `Pattern.Core` and `Pattern.Graph`
+(map, filter) can be redefined against `ScopeQuery q v` in the same way. This is
+deferred to a follow-on cleanup pass once `paraWithScope` is in place and the pattern
+is confirmed.
+
+---
+
+## Module placement
+
+| Definition | Module | Action |
+|---|---|---|
+| `ScopeQuery` typeclass | `Pattern.Core` | **New** |
+| `TrivialScope` + `trivialScope` | `Pattern.Core` | **New** |
+| `ScopeDict` + `toDict` | `Pattern.Core` | **New** |
+| `paraWithScope` | `Pattern.Core` | **New** |
+| `para` | `Pattern.Core` | **Redefine** (no API change) |
+| `GraphScope` typeclass | `Pattern.Graph` | **New** |
+| `ScopeQuery GraphQuery` instance | `Pattern.Graph` | **New** |
+| `GraphScope GraphQuery` instance | `Pattern.Graph` | **New** |
+| `paraGraph` | `Pattern.Graph` | **Redefine** (no API change) |
+
+No existing definitions are removed. No existing call sites require changes.
+
+---
+
+## Interface convention note
+
+This proposal introduces `ScopeQuery` and `GraphScope` as typeclasses rather than
+records-of-functions. This is a deliberate choice for new interfaces in `pattern-hs`
+going forward, and the reasoning is documented here to be explicit.
+
+The existing `GraphQuery` and `GraphClassifier` records are **not** converted — that
+would be a breaking change with limited benefit. Instead they gain typeclass instances,
+which is purely additive.
+
+For new interfaces from this point forward:
+
+1. Define the interface as a typeclass
+2. Provide a `*Dict` record as the first-class value form, with a `toDict` reification
+3. Give existing records typeclass instances where they satisfy the interface
+4. Document the cross-language correspondence in the porting guide
+
+**Cross-language correspondence:**
+
+| Haskell | Rust | Python / TypeScript (via WASM) |
+|---|---|---|
+| Typeclass | Trait | Protocol / Interface |
+| `*Dict` record | Struct implementing trait | Concrete class |
+| `toDict` | `impl Trait for Struct` | `__init__` + protocol conformance |
+| `&dyn ScopeQuery<V>` (at boundary) | `Box<dyn ScopeQuery<V>>` | WASM-exported object |
+
+The Rust port uses `&dyn ScopeQuery<V>` at FFI and dynamic-dispatch boundaries. Within
+Rust, monomorphic trait bounds (`impl ScopeQuery<V>`) are preferred for performance.
+The porting guide should document this correspondence explicitly when the Rust port of
+this proposal is undertaken.
+
+---
+
+## Implementation sequence
+
+### Step 1 — helpers in `Pattern.Core`
+
+Confirm that `findInSubtree` and `subtreeElements` exist and are correct. Add them if
+missing. These are simple recursive traversals; their correctness is a prerequisite for
+`TrivialScope`.
+
+### Step 2 — `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toDict`
+
+Add to `Pattern.Core`. No dependencies on other new definitions. Write unit tests
+for `TrivialScope`: `containers` and `siblings` return `[]`; `byIdentity` finds
+elements within the subtree; `allElements` enumerates the full subtree.
+
+### Step 3 — `paraWithScope` in `Pattern.Core`
+
+Implement `paraWithScope`. Redefine `para` in terms of it. Run the existing `para`
+test suite — all tests must pass without modification. This is the primary correctness
+check: if `para` is behaviorally identical before and after, the refactoring is sound.
+
+### Step 4 — `GraphScope`, instances in `Pattern.Graph`
+
+Add `GraphScope` typeclass to `Pattern.Graph`. Add `ScopeQuery GraphQuery` and
+`GraphScope GraphQuery` instances. Redefine `paraGraph` in terms of `paraWithScope`.
+Run the existing `paraGraph` test suite — all tests must pass without modification.
+
+### Step 5 — verify no regressions
+
+Run the full `pattern-hs` test suite. No failures expected. No call sites should
+require changes.
+
+---
+
+## What this does not include
+
+This proposal deliberately excludes the following, which belong to later proposals:
+
+- **`RepresentationMap`** — named invertible maps between kinds of shape. Depends on
+  this proposal and on `GraphTransform`. See `representation-map-proposal.md`.
+- **`PatternKind`** — named, predicate-defined shape kinds. Part of the
+  `RepresentationMap` proposal.
+- **Interface convention for `GraphClassifier`** — `GraphClassifier` can gain a
+  typeclass instance following the same pattern as `GraphQuery`, but that change is
+  deferred to avoid scope creep here.
+- **`mapWithContext` and `filterGraph` redefinitions** — these can be redefined against
+  `ScopeQuery q v` once `paraWithScope` is in place, but are a follow-on cleanup, not
+  a prerequisite.
+- **Rust port** — the Rust port of this proposal follows the standard
+  typeclass-to-trait correspondence. That work belongs in `pattern-rs` and is not
+  scheduled here.
+
+---
+
+## Acceptance criteria
+
+The implementation is complete when:
+
+1. `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toDict`, and `paraWithScope` are
+   present in `Pattern.Core` and exported.
+2. `GraphScope`, `ScopeQuery GraphQuery`, and `GraphScope GraphQuery` are present in
+   `Pattern.Graph` and exported.
+3. `para` and `paraGraph` are redefined as derived operations and pass their existing
+   test suites without modification.
+4. The full `pattern-hs` test suite passes with no failures.
+5. No existing call sites required changes.
+
+---
+
+## Related documents
+
+- `representation-map-proposal.md` — the larger proposal this is extracted from;
+  `RepresentationMap` depends on this proposal being implemented first
+- `proposals/graph-query.md` — `GraphQuery` record that gains `ScopeQuery` and
+  `GraphScope` instances here
+- `proposals/graph-transform.md` — the next proposal in sequence after this one is
+  merged; `RepresentationMap` depends on both

--- a/specs/038-scope-unification/checklists/requirements.md
+++ b/specs/038-scope-unification/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Scope Unification for Structure-Aware Operations
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-03-17  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 completed with no unresolved issues.
+- The specification stays focused on externally observable behavior, compatibility expectations, and extensibility outcomes rather than implementation steps.
+- No clarification round is required before `/speckit.plan`.

--- a/specs/038-scope-unification/contracts/Pattern.Core.hs
+++ b/specs/038-scope-unification/contracts/Pattern.Core.hs
@@ -1,0 +1,51 @@
+module Pattern.Core
+  ( Pattern(..)
+  , ScopeQuery(..)
+  , TrivialScope
+  , trivialScope
+  , ScopeDict(..)
+  , toScopeDict
+  , para
+  , paraWithScope
+  ) where
+
+import Pattern.Core (Pattern(..))
+
+-- Generic contract for "what is in scope" during a structure-aware operation.
+class ScopeQuery q v where
+  containers  :: q v -> Pattern v -> [Pattern v]
+  siblings    :: q v -> Pattern v -> [Pattern v]
+  byIdentity  :: q v -> Id v -> Maybe (Pattern v)
+  allElements :: q v -> [Pattern v]
+
+-- Subtree-only scope used to preserve para semantics.
+newtype TrivialScope v = TrivialScope (Pattern v)
+
+trivialScope :: Pattern v -> TrivialScope v
+
+-- First-class value form for stored/dynamic scope behavior.
+data ScopeDict v = ScopeDict
+  { dictContainers  :: Pattern v -> [Pattern v]
+  , dictSiblings    :: Pattern v -> [Pattern v]
+  , dictByIdentity  :: Id v -> Maybe (Pattern v)
+  , dictAllElements :: [Pattern v]
+  }
+
+instance ScopeQuery ScopeDict v where
+  containers  = dictContainers
+  siblings    = dictSiblings
+  byIdentity  = dictByIdentity
+  allElements = dictAllElements
+
+toScopeDict :: ScopeQuery q v => q v -> ScopeDict v
+
+-- Existing wrapper preserved.
+para :: (Pattern v -> [r] -> r) -> Pattern v -> r
+
+-- Canonical scope-aware tree fold.
+paraWithScope
+  :: ScopeQuery q v
+  => q v
+  -> (q v -> Pattern v -> [r] -> r)
+  -> Pattern v
+  -> r

--- a/specs/038-scope-unification/contracts/Pattern.Core.hs
+++ b/specs/038-scope-unification/contracts/Pattern.Core.hs
@@ -13,9 +13,11 @@ import Pattern.Core (Pattern(..))
 
 -- Generic contract for "what is in scope" during a structure-aware operation.
 class ScopeQuery q v where
+  type ScopeId q v
+
   containers  :: q v -> Pattern v -> [Pattern v]
   siblings    :: q v -> Pattern v -> [Pattern v]
-  byIdentity  :: q v -> Id v -> Maybe (Pattern v)
+  byIdentity  :: q v -> ScopeId q v -> Maybe (Pattern v)
   allElements :: q v -> [Pattern v]
 
 -- Subtree-only scope used to preserve para semantics.
@@ -24,20 +26,22 @@ newtype TrivialScope v = TrivialScope (Pattern v)
 trivialScope :: Pattern v -> TrivialScope v
 
 -- First-class value form for stored/dynamic scope behavior.
-data ScopeDict v = ScopeDict
+data ScopeDict i v = ScopeDict
   { dictContainers  :: Pattern v -> [Pattern v]
   , dictSiblings    :: Pattern v -> [Pattern v]
-  , dictByIdentity  :: Id v -> Maybe (Pattern v)
+  , dictByIdentity  :: i -> Maybe (Pattern v)
   , dictAllElements :: [Pattern v]
   }
 
-instance ScopeQuery ScopeDict v where
+instance ScopeQuery (ScopeDict i) v where
+  type ScopeId (ScopeDict i) v = i
+
   containers  = dictContainers
   siblings    = dictSiblings
   byIdentity  = dictByIdentity
   allElements = dictAllElements
 
-toScopeDict :: ScopeQuery q v => q v -> ScopeDict v
+toScopeDict :: ScopeQuery q v => q v -> ScopeDict (ScopeId q v) v
 
 -- Existing wrapper preserved.
 para :: (Pattern v -> [r] -> r) -> Pattern v -> r

--- a/specs/038-scope-unification/contracts/Pattern.Graph.Transform.hs
+++ b/specs/038-scope-unification/contracts/Pattern.Graph.Transform.hs
@@ -1,0 +1,37 @@
+module Pattern.Graph.Transform
+  ( paraGraph
+  , paraGraphFixed
+  ) where
+
+import Data.Map.Strict (Map)
+import Pattern.Core (Pattern(..), ScopeQuery, ScopeDict)
+import Pattern.Graph.GraphClassifier (GraphValue(..))
+import Pattern.Graph.GraphQuery (GraphQuery(..))
+import Pattern.Graph.Types (GraphView(..))
+
+-- Internal adapter that exposes full GraphView scope to the generic scope layer
+-- without changing the public GraphQuery record shape.
+data GraphViewScope v = GraphViewScope
+  { gvsQuery    :: GraphQuery v
+  , gvsElements :: [Pattern v]
+  , gvsIndex    :: Id v -> Maybe (Pattern v)
+  }
+
+instance ScopeQuery GraphViewScope v
+
+graphViewScope :: GraphValue v => GraphView extra v -> GraphViewScope v
+
+-- Existing public API remains unchanged.
+paraGraph
+  :: GraphValue v
+  => (GraphQuery v -> Pattern v -> [r] -> r)
+  -> GraphView extra v
+  -> Map (Id v) r
+
+paraGraphFixed
+  :: (GraphValue v, Ord (Id v))
+  => (r -> r -> Bool)
+  -> (GraphQuery v -> Pattern v -> [r] -> r)
+  -> r
+  -> GraphView extra v
+  -> Map (Id v) r

--- a/specs/038-scope-unification/contracts/Pattern.Graph.Transform.hs
+++ b/specs/038-scope-unification/contracts/Pattern.Graph.Transform.hs
@@ -1,10 +1,11 @@
 module Pattern.Graph.Transform
-  ( paraGraph
+  ( scopeDictFromGraphView
+  , paraGraph
   , paraGraphFixed
   ) where
 
 import Data.Map.Strict (Map)
-import Pattern.Core (Pattern(..), ScopeQuery, ScopeDict)
+import Pattern.Core (Pattern(..), ScopeQuery(..), ScopeDict)
 import Pattern.Graph.GraphClassifier (GraphValue(..))
 import Pattern.Graph.GraphQuery (GraphQuery(..))
 import Pattern.Graph.Types (GraphView(..))
@@ -12,12 +13,16 @@ import Pattern.Graph.Types (GraphView(..))
 -- Internal adapter that exposes full GraphView scope to the generic scope layer
 -- without changing the public GraphQuery record shape.
 data GraphViewScope v = GraphViewScope
-  { gvsQuery    :: GraphQuery v
-  , gvsElements :: [Pattern v]
-  , gvsIndex    :: Id v -> Maybe (Pattern v)
+  { gvsQuery      :: GraphQuery v
+  , gvsElements   :: [Pattern v]
+  , gvsIndex      :: Map (Id v) (Pattern v)
+  , gvsContainers :: Map (Id v) [Pattern v]
   }
 
-instance ScopeQuery GraphViewScope v
+instance ScopeQuery GraphViewScope v where
+  type ScopeId GraphViewScope v = Id v
+
+scopeDictFromGraphView :: GraphValue v => GraphView extra v -> ScopeDict (Id v) v
 
 graphViewScope :: GraphValue v => GraphView extra v -> GraphViewScope v
 

--- a/specs/038-scope-unification/data-model.md
+++ b/specs/038-scope-unification/data-model.md
@@ -1,0 +1,130 @@
+# Data Model: Scope Unification for Structure-Aware Operations
+
+**Branch**: `038-scope-unification` | **Date**: 2026-03-17
+
+## Overview
+
+This feature does not introduce persisted storage. The "data model" is the public in-memory API surface that defines how scope-aware folding is represented and how existing graph/tree behavior is preserved.
+
+## Entities
+
+### 1. `ScopeQuery`
+
+**Purpose**: The generic contract for "what is in scope" during a structure-aware operation.
+
+**Core behaviors**:
+- `containers`: direct containers of an element within the current scope
+- `siblings`: co-elements sharing the same direct parent/container within the current scope
+- `byIdentity`: direct lookup of an in-scope element by identity
+- `allElements`: complete enumeration of the current scope
+
+**Validation rules**:
+- Must answer only for the current scope boundary.
+- Must not infer a broader enclosing scope than the caller supplied.
+- Must return empty results rather than errors when a query is unsupported by the chosen scope.
+
+**Relationships**:
+- Implemented by `TrivialScope`
+- Reified as `ScopeDict`
+- Consumed by `paraWithScope`
+
+### 2. `TrivialScope`
+
+**Purpose**: The subtree-only scope used to preserve current `para` behavior.
+
+**Fields / state**:
+- `rootPattern`: the `Pattern v` that defines the subtree boundary
+
+**Validation rules**:
+- `byIdentity` searches only within the subtree rooted at `rootPattern`
+- `allElements` enumerates only that subtree
+- `containers` and `siblings` return empty results because this scope lacks parent/sibling context
+
+**Relationships**:
+- Implements `ScopeQuery`
+- Used by `para` as the default scope adapter
+
+### 3. `ScopeDict`
+
+**Purpose**: First-class value representation of scope behavior for dynamic composition and storage.
+
+**Fields / state**:
+- containment function
+- sibling function
+- identity lookup function
+- all-elements enumeration value or function
+
+**Validation rules**:
+- Must be observationally equivalent to the scope provider from which it was reified
+- Must preserve scope boundary semantics
+
+**Relationships**:
+- Reified from any `ScopeQuery` implementation via `toScopeDict`
+- Implements `ScopeQuery` itself
+
+### 4. `GraphViewScope` Adapter
+
+**Purpose**: Adapter that answers generic scope queries across all classified elements present in a `GraphView` without changing `GraphQuery(..)`.
+
+**Fields / state**:
+- `baseQuery`: the existing `GraphQuery v` snapshot for graph-topology operations
+- `viewElements`: the classified element list from `GraphView`
+- `elementIndex`: identity-based index over all classified elements in the view
+
+**Validation rules**:
+- Must cover all classified elements in the `GraphView`, not just nodes and relationships
+- Must preserve the `GraphView` snapshot boundary for the duration of a fold
+- Must remain additive and not require new fields on `GraphQuery`
+
+**Relationships**:
+- Built from `GraphView`
+- Supplies generic scope answers for graph-aware planning/implementation
+- Delegates graph-topology queries to `baseQuery`
+
+### 5. `Scope-Aware Fold Step`
+
+**Purpose**: The algebra used by the unified fold contract.
+
+**Inputs**:
+- current scope provider
+- current `Pattern v`
+- already-computed direct child results in element order
+
+**Validation rules**:
+- Child results must be bottom-up
+- Scope must remain fixed for the full fold
+- `para` compatibility requires full child-result completeness for recursive tree folds
+- `paraGraph` compatibility requires best-effort omission for graph cycle cases
+
+**Relationships**:
+- Executed by `paraWithScope`
+- Reused conceptually by `para` and `paraGraph` wrappers
+
+## Behavioral Relationships
+
+### Scope Boundary
+
+- `TrivialScope` defines scope from one subtree root.
+- `GraphViewScope` defines scope from the full `GraphView` snapshot.
+- `ScopeDict` preserves whichever scope boundary it reifies.
+
+### Wrapper Preservation
+
+- `para` = `paraWithScope` + `TrivialScope`
+- `paraGraph` = graph-specific scheduling/accumulation wrapper that preserves current output while using the shared scope model
+
+## State Transitions
+
+This feature is pure and in-memory. The relevant transitions are conceptual:
+
+1. A caller chooses a scope boundary.
+2. That boundary is represented as a `ScopeQuery` implementation or `ScopeDict`.
+3. A structure-aware fold runs with that scope fixed for the duration of the operation.
+4. Existing wrappers (`para`, `paraGraph`) preserve their current externally visible outputs.
+
+## Test-Critical Invariants
+
+- `paraWithScope (trivialScope p)` is observationally equivalent to `para p`.
+- Reifying a scope provider with `toScopeDict` does not change any generic scope answers.
+- Narrower scopes never expose elements outside their declared boundary.
+- `paraGraph` preserves existing `topoShapeSort` ordering and cycle soft-failure semantics.

--- a/specs/038-scope-unification/plan.md
+++ b/specs/038-scope-unification/plan.md
@@ -1,0 +1,131 @@
+# Implementation Plan: Scope Unification for Structure-Aware Operations
+
+**Branch**: `038-scope-unification` | **Date**: 2026-03-17 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/038-scope-unification/spec.md`
+
+## Summary
+
+Introduce a shared scope abstraction for structure-aware folding in `libs/pattern`, centered on `ScopeQuery`, `TrivialScope`, `ScopeDict`, and `paraWithScope` in `Pattern.Core`. Preserve the existing public behavior of `para` and `paraGraph` by keeping them as wrappers, while adapting graph-wide scope through an internal `GraphView`-backed adapter rather than widening `GraphQuery` itself. The implementation remains additive, keeps `topoShapeSort` and current graph ordering semantics intact, and adds documentation plus tests for the new public abstractions.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.12.2)  
+**Primary Dependencies**: `base`, `containers`, existing `pattern` modules (`Pattern.Core`, `Pattern.Graph`, `Pattern.Graph.GraphQuery`, `Pattern.Graph.Transform`)  
+**Storage**: N/A - pure in-memory library behavior  
+**Testing**: `hspec` and `QuickCheck` via `libs/pattern/tests`; compatibility suites in `Spec.Pattern.CoreSpec` and `Spec.Pattern.Graph.TransformSpec`  
+**Target Platform**: Cross-platform library/reference implementation  
+**Project Type**: Multi-package Haskell workspace; feature scope is concentrated in `libs/pattern`  
+**Performance Goals**: Preserve current asymptotic behavior for `para`; keep `paraGraph` as a single pass over `topoShapeSort` output; subtree lookups/enumeration may remain linear in subtree size  
+**Constraints**: Additive-only public change; no existing call-site changes; preserve `paraGraph` best-effort cycle behavior; avoid breaking the public `GraphQuery(..)` record by using an adapter for full-scope enumeration/lookup  
+**Scale/Scope**: 4-6 source modules, 2-4 test modules, and 3 reference docs in `docs/reference`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+### Pre-Design Gate
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality | ✅ Pass | New public abstractions will be documented explicitly and kept additive rather than replacing existing types. |
+| II. Testing Standards | ✅ Pass | Plan includes compatibility tests for `para`/`paraGraph`, unit tests for new scope APIs, and property tests for equivalence and scope boundaries. |
+| III. Conceptual Consistency | ✅ Pass | The design makes scope boundary an explicit concept shared by tree and graph folds. |
+| IV. Mathematical Clarity | ✅ Pass | Plan includes formal contracts for the scope interface, fold invariants, and scope-boundary semantics. |
+| V. Multi-Language Reference Alignment | ✅ Pass | Typeclass + first-class dictionary/value-form correspondence will be documented in the porting guide. |
+
+### Post-Design Gate
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Code Quality | ✅ Pass | `research.md`, `data-model.md`, contracts, and quickstart keep the new API surface small and clearly separated by module responsibility. |
+| II. Testing Standards | ✅ Pass | Design artifacts define unit, integration, and property-level coverage for new and preserved behavior. |
+| III. Conceptual Consistency | ✅ Pass | The graph adapter decision preserves the unified scope model without changing the meaning of `GraphQuery`. |
+| IV. Mathematical Clarity | ✅ Pass | Contracts and quickstart describe bottom-up folding, fixed-scope semantics, and observational equivalence of dictionary forms. |
+| V. Multi-Language Reference Alignment | ✅ Pass | The design explicitly documents how the Haskell typeclass maps to trait/protocol/interface-style implementations in other languages. |
+
+*No gate failures. No Complexity Tracking entry required.*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/038-scope-unification/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── Pattern.Core.hs
+│   └── Pattern.Graph.Transform.hs
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+libs/pattern/src/
+├── Pattern/Core.hs                  # New scope abstractions + paraWithScope + para wrapper update
+├── Pattern/Graph.hs                 # Touch only if graph-side public docs or exports need adjustment
+├── Pattern/Graph/Transform.hs       # Internal graph adapter + paraGraph/paraGraphFixed wrapper updates
+└── Pattern.hs                       # Top-level re-exports for new public generic scope APIs if needed
+
+libs/pattern/tests/
+├── Spec/Pattern/CoreSpec.hs         # New ScopeQuery / TrivialScope / ScopeDict / paraWithScope tests
+├── Spec/Pattern/Graph/TransformSpec.hs
+└── Test.hs
+
+docs/reference/
+├── PORTING-GUIDE.md                 # Cross-language mapping for scope abstractions
+└── features/
+   ├── paramorphism.md               # Unified fold model for para / paraWithScope
+   └── para-graph.md                 # Graph-side scope-aware fold explanation
+```
+
+**Structure Decision**: Keep the implementation inside the existing `libs/pattern` library. Put the generic scope contract in `Pattern.Core`, keep graph-specific scheduling in `Pattern.Graph.Transform`, and only add re-exports where needed to preserve discoverability without moving existing responsibilities across packages.
+
+## Phase 0: Research
+
+See [research.md](./research.md).
+
+Key Phase 0 outcomes to carry into implementation:
+- Use a typeclass plus first-class dictionary/value form for generic scope behavior.
+- Preserve `GraphQuery(..)` unchanged and bridge graph scope through an internal `GraphView`-backed adapter.
+- Treat `paraWithScope` as the canonical scope-aware tree fold, while `paraGraph` remains a graph-specific wrapper preserving `Map` output and `topoShapeSort` scheduling.
+
+## Phase 1: Design
+
+See [data-model.md](./data-model.md), [quickstart.md](./quickstart.md), and the contracts in [contracts/Pattern.Core.hs](./contracts/Pattern.Core.hs) and [contracts/Pattern.Graph.Transform.hs](./contracts/Pattern.Graph.Transform.hs).
+
+### Design Notes
+
+1. `Pattern.Core` owns the generic contract:
+   - `ScopeQuery`
+   - `TrivialScope`
+   - `ScopeDict`
+   - `toScopeDict`
+   - `paraWithScope`
+
+2. Graph-wide scope is adapted, not redefined:
+   - An internal `GraphView`-backed adapter supplies generic scope answers for all classified elements in the view.
+   - Existing `GraphQuery` remains the public graph-topology interface passed to current `paraGraph` callers.
+
+3. Testing is split by responsibility:
+   - Compatibility: existing `para` and `paraGraph` suites pass unchanged.
+   - New API verification: unit tests for scope operations, explicit subtree empty-result behavior, and dictionary equivalence.
+   - Behavioral guarantees: QuickCheck property tests for `paraWithScope (trivialScope p)` matching `para`, plus scope reification and boundary laws where applicable.
+
+4. Documentation is part of the implementation scope:
+   - `paramorphism.md` explains `paraWithScope` and the relationship to `para`
+   - `para-graph.md` explains graph scheduling plus shared scope semantics
+   - `PORTING-GUIDE.md` explains typeclass/dictionary correspondence for ports
+   - Source-level docs include categorical meaning, invariants, and usage examples for every new public type and function
+
+5. Validation includes non-functional guardrails:
+   - review the final implementation to confirm `para` preserves its existing asymptotic behavior
+   - review the graph wrapper to confirm `paraGraph` remains a single pass over `topoShapeSort`
+   - audit final changes against the spec boundary so broader cleanup work is not pulled into this feature
+
+## Complexity Tracking
+
+No constitution violations or exceptional complexity are planned at this stage.

--- a/specs/038-scope-unification/quickstart.md
+++ b/specs/038-scope-unification/quickstart.md
@@ -61,10 +61,10 @@ Document:
 Run the pattern test suite:
 
 ```bash
-cabal test pattern-test
+cabal test --enable-tests pattern:test:pattern-test
 ```
 
-If the workspace requires package-qualified execution, run from repo root with the existing package configuration.
+Run from repo root. This workspace currently requires the explicit `--enable-tests` package-qualified form so Cabal includes the `pattern-test` suite in the solver plan.
 
 ## Expected Outcome
 

--- a/specs/038-scope-unification/quickstart.md
+++ b/specs/038-scope-unification/quickstart.md
@@ -1,0 +1,74 @@
+# Quickstart: Scope Unification for Structure-Aware Operations
+
+**Branch**: `038-scope-unification`
+
+## Goal
+
+Implement the shared scope model in `libs/pattern` while preserving the current behavior of `para` and `paraGraph`.
+
+## 1. Implement the generic scope contract
+
+Update `libs/pattern/src/Pattern/Core.hs` to add:
+- `ScopeQuery`
+- `TrivialScope`
+- `ScopeDict`
+- `toScopeDict`
+- `paraWithScope`
+
+Keep the existing `para` export and redefine it as the wrapper over `paraWithScope` plus `TrivialScope`.
+
+## 2. Add graph-side scope adaptation
+
+Update the graph-side implementation so the unified scope layer can answer generic scope questions across a full `GraphView` without changing the existing `GraphQuery(..)` record shape.
+
+Likely touchpoints:
+- `libs/pattern/src/Pattern/Graph/Transform.hs`
+- `libs/pattern/src/Pattern/Graph/Types.hs`
+- `libs/pattern/src/Pattern/Graph.hs` if public re-exports are needed
+
+Keep these behaviors unchanged:
+- `paraGraph` returns `Map (Id v) r`
+- `paraGraph` still uses `topoShapeSort`
+- cycle members still omit unavailable `subResults` rather than failing
+
+## 3. Add and update tests
+
+Update `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` with:
+- `TrivialScope` behavior tests
+- `ScopeDict` observational equivalence tests
+- `paraWithScope` bottom-up behavior tests
+- property or representative-equivalence test that `paraWithScope (trivialScope p)` matches `para`
+
+Update `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` with:
+- wrapper-preservation coverage for `paraGraph`
+- any graph adapter tests needed for generic scope answers
+- confirmation that existing annotation / `GOther` / cycle cases remain unchanged
+
+## 4. Refresh reference docs
+
+Update:
+- `docs/reference/features/paramorphism.md`
+- `docs/reference/features/para-graph.md`
+- `docs/reference/PORTING-GUIDE.md`
+
+Document:
+- one unified scope mental model
+- tree scope vs graph scope boundaries
+- typeclass plus dictionary/value-form correspondence for ports
+
+## 5. Verification
+
+Run the pattern test suite:
+
+```bash
+cabal test pattern-test
+```
+
+If the workspace requires package-qualified execution, run from repo root with the existing package configuration.
+
+## Expected Outcome
+
+- `para` callers change nothing
+- `paraGraph` callers change nothing
+- new scope abstractions are documented and tested
+- the library has one explicit model of scope for structure-aware operations

--- a/specs/038-scope-unification/research.md
+++ b/specs/038-scope-unification/research.md
@@ -1,0 +1,110 @@
+# Research: Scope Unification for Structure-Aware Operations
+
+**Branch**: `038-scope-unification` | **Date**: 2026-03-17  
+**Purpose**: Resolve implementation-design unknowns before coding.
+
+---
+
+## Decision 1: Represent Generic Scope as a Typeclass Plus First-Class Dictionary
+
+**Decision**: Introduce generic scope behavior in `Pattern.Core` as a typeclass (`ScopeQuery`) with a first-class value form (`ScopeDict`) and a reification helper (`toScopeDict`).
+
+**Rationale**: This follows the reference-design pattern already emerging in the repo: use static dispatch for the common case, but provide a stored/dynamic form when higher-order utilities need to pass scope behavior around as data. It also aligns with the proposal's intent and the constitution's cross-language requirement by making the Haskell design easy to map to traits, protocols, or interfaces elsewhere.
+
+**Alternatives considered**:
+- Record-of-functions only — rejected because the generic case reads better as a typeclass in Haskell and should not force all callers into dynamic dispatch.
+- Typeclass only — rejected because the spec explicitly requires first-class scope behavior for storage and composition use cases.
+
+---
+
+## Decision 2: Keep `paraWithScope` in `Pattern.Core` as the Canonical Tree Fold
+
+**Decision**: Add `paraWithScope` in `Pattern.Core` as the canonical scope-aware fold for recursive `Pattern` traversal, and redefine `para` in terms of it using `TrivialScope`.
+
+**Rationale**: `para` already has a precise and well-tested recursive contract over a single `Pattern`. Making the scope explicit there is straightforward and preserves the conceptual relationship between the original paramorphism and the new abstraction. This gives a stable generic fold contract without disturbing the existing `para` API.
+
+**Alternatives considered**:
+- Replace `para` outright with a differently shaped public API — rejected because the spec requires zero call-site changes.
+- Generalize the fold first around a flat list scheduler — rejected because the tree paramorphism is already correct and should remain the conceptual baseline.
+
+---
+
+## Decision 3: Adapt Graph-Wide Scope Through `GraphView`, Not by Expanding `GraphQuery`
+
+**Decision**: Provide graph-wide generic scope answers through a `GraphView`-backed adapter rather than by adding new fields to `GraphQuery`.
+
+**Rationale**: The current public `GraphQuery(..)` record enumerates nodes and relationships and exposes node/relationship lookups plus direct-container queries. It does not provide complete enumeration or lookup across walks, annotations, and other classified elements. Adding new record fields would be a breaking API change for downstream record construction and pattern matching. A `GraphView`-backed adapter preserves additive-only change while giving the unified scope layer access to all in-scope graph elements.
+
+**Alternatives considered**:
+- Add generic-scope fields directly to `GraphQuery` — rejected because adding public record fields is breaking.
+- Treat `GraphQuery` as if it already represented full graph scope — rejected because it would make `allElements` and generic identity lookup incomplete for classified graph elements beyond nodes and relationships.
+
+---
+
+## Decision 4: Preserve `paraGraph` as a Wrapper With Existing Map Output and Scheduling
+
+**Decision**: Keep `paraGraph` and `paraGraphFixed` as graph-specific wrappers that preserve `Map (Id v) r` output, `topoShapeSort` scheduling, and current best-effort cycle behavior.
+
+**Rationale**: The current `GraphView` is a flat classified element list, not a rooted recursive structure. A direct substitution of `paraGraph` with the tree-shaped `paraWithScope` would either require a synthetic root or duplicate element visits, both of which would distort current semantics. The correct additive design is to unify scope semantics while retaining the graph-specific accumulation strategy that existing tests already lock in.
+
+**Alternatives considered**:
+- Convert `GraphView` into a rooted pattern and run `paraWithScope` directly — rejected because the current graph fold is defined over a flat view and returns one result per element keyed by identity.
+- Change `paraGraph` to return a single fold result — rejected because it would break the public contract.
+
+---
+
+## Decision 5: Subtree Scope Returns Empty Answers for Missing Parent/Sibling Context
+
+**Decision**: The subtree-only scope used for `para` returns empty results for parent- and sibling-oriented queries when that information is unavailable.
+
+**Rationale**: This matches the feature spec and keeps the generic scope contract total rather than partial. It also makes the subtree scope easy to reason about across languages: unavailable context means empty answer, not exception or sentinel failure.
+
+**Alternatives considered**:
+- Raise errors for unsupported queries — rejected because it would make generic scope consumers brittle and violate the spec's edge-case expectations.
+- Return `Maybe [Pattern v]` for some queries — rejected because it complicates the shared contract and leaks implementation availability into every caller.
+
+---
+
+## Decision 6: Add Explicit Tests for the New Public Abstractions
+
+**Decision**: Expand test coverage beyond compatibility reruns to include unit tests for `TrivialScope`, `ScopeDict`, and `paraWithScope`, plus at least one property-level equivalence check between `para` and `paraWithScope (trivialScope p)`.
+
+**Rationale**: The constitution requires tests for every public function/type, plus edge cases and mathematically meaningful properties. Rerunning only the old suites would prove backward compatibility but would not specify the behavior of the new API surface itself.
+
+**Alternatives considered**:
+- Only rely on existing `para` / `paraGraph` suites — rejected because the new abstractions would remain under-specified.
+- Add only unit tests and skip property tests — rejected because observational equivalence and scope-boundary laws are natural property-level requirements here.
+
+---
+
+## Decision 7: Update Existing Reference Docs Instead of Adding a New Feature Doc
+
+**Decision**: Update `docs/reference/features/paramorphism.md`, `docs/reference/features/para-graph.md`, and `docs/reference/PORTING-GUIDE.md` instead of introducing a separate third feature reference file.
+
+**Rationale**: The user-facing concepts already live in those docs. Updating them keeps the reference narrative coherent: `para` and `paraGraph` remain the entry points readers know, and the new scope abstraction explains their shared mental model rather than fragmenting the docs.
+
+**Alternatives considered**:
+- Create a brand-new `scope-query.md` feature doc — rejected for this feature because it would duplicate explanations already required in the paramorphism and graph-fold docs.
+- Leave the docs untouched and rely on Haddocks — rejected because the constitution requires clear conceptual and cross-language documentation for reference features.
+
+---
+
+## Decision 8: Cross-Language Mapping Must Be Documented as Typeclass ↔ Dictionary ↔ Trait/Protocol
+
+**Decision**: Document the cross-language mapping explicitly in the porting guide: Haskell typeclass + dictionary/value form corresponds to trait/object/protocol plus a concrete adapter in other target languages.
+
+**Rationale**: This feature is a reference-design abstraction, not a Haskell-only convenience. Without the mapping note, ports may copy syntax rather than semantics and drift on what "scope" means.
+
+**Alternatives considered**:
+- Leave cross-language implications implicit — rejected because the constitution makes multi-language alignment a first-class requirement.
+
+---
+
+## Resolved Questions
+
+| Question | Resolution |
+|----------|------------|
+| Should graph-wide scope be represented directly by `GraphQuery`? | No. Use a `GraphView`-backed adapter so the change stays additive and covers all classified elements. |
+| Does the unified fold replace `paraGraph` outright? | No. `paraWithScope` becomes the canonical scope-aware tree fold; `paraGraph` remains a graph-specific wrapper preserving current output and scheduling. |
+| How should unsupported subtree queries behave? | Return empty results, not errors. |
+| Are compatibility tests alone sufficient? | No. New public abstractions require unit and property-level tests in addition to compatibility checks. |

--- a/specs/038-scope-unification/spec.md
+++ b/specs/038-scope-unification/spec.md
@@ -3,7 +3,7 @@
 **Feature Branch**: `038-scope-unification`  
 **Created**: 2026-03-17  
 **Status**: Draft  
-**Input**: User description: "Unify the use of scope for stucture+scope aware operations as described in @proposals/scope-unification-proposal.md"
+**Input**: User description: "Unify the use of scope for structure+scope aware operations as described in @proposals/scope-unification-proposal.md"
 
 ## User Scenarios & Testing *(mandatory)*
 

--- a/specs/038-scope-unification/spec.md
+++ b/specs/038-scope-unification/spec.md
@@ -1,0 +1,108 @@
+# Feature Specification: Scope Unification for Structure-Aware Operations
+
+**Feature Branch**: `038-scope-unification`  
+**Created**: 2026-03-17  
+**Status**: Draft  
+**Input**: User description: "Unify the use of scope for stucture+scope aware operations as described in @proposals/scope-unification-proposal.md"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Preserve existing fold behavior through one unified scope model (Priority: P1)
+
+A developer already using `para` or `paraGraph` wants the library to expose one shared model for scope-aware folding without changing the behavior of their existing code. They should be able to keep using the current entry points and get the same results as before, while the library internally treats both operations as the same kind of fold with different scope boundaries.
+
+**Why this priority**: Preserving existing behavior while removing duplication is the core value of the feature. If current callers must change code or receive different results, the unification fails its primary purpose.
+
+**Independent Test**: Run the existing `para` and `paraGraph` test suites without modifying call sites or expected outputs. Confirm all tests still pass and the same observable results are produced.
+
+**Acceptance Scenarios**:
+
+1. **Given** existing code that uses `para`, **When** the unified scope feature is introduced, **Then** the code continues to work without call-site changes and returns the same results as before.
+2. **Given** existing code that uses `paraGraph`, **When** the unified scope feature is introduced, **Then** the code continues to work without call-site changes and returns the same results as before.
+3. **Given** a developer uses the new unified fold directly with an explicit scope, **When** the fold runs, **Then** each step receives the current element, the already-computed child results, and access to the same containing scope for the entire fold.
+
+---
+
+### User Story 2 - Add new scope-aware behavior without inventing new fold primitives (Priority: P2)
+
+A developer introducing a new kind of containing context, such as a document-wide or subgraph-wide view, wants to reuse the same fold primitive instead of adding another specialized fold API. They should be able to describe what is in scope once and then use the unified fold for structure-aware operations in that context.
+
+**Why this priority**: The main strategic value of scope unification is extensibility. Once the shared scope contract exists, new scope kinds can participate without duplicating fold logic.
+
+**Independent Test**: Define a non-graph scope provider that can answer the generic scope questions, run the unified fold against it, and confirm the fold can read scope information without requiring a new specialized fold entry point.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new scope provider that can report containment, siblings, identity lookup, and all in-scope elements, **When** a developer uses it with the unified fold, **Then** the fold operates correctly without introducing a new fold primitive.
+2. **Given** a structure-aware operation that only needs generic scope information, **When** it is written against the unified scope contract, **Then** it works across both subtree-only and graph-wide scopes.
+
+---
+
+### User Story 3 - Pass scope behavior around as data when needed (Priority: P3)
+
+A developer maintaining higher-order utilities wants to store, pass, or compose scope behavior in places where a direct polymorphic scope value is inconvenient. They need a first-class representation of scope that behaves the same way as the direct scope provider for the core scope operations.
+
+**Why this priority**: This is a supporting capability rather than the main user-visible outcome, but it removes friction for composition and dynamic use cases that would otherwise be blocked by the new abstraction.
+
+**Independent Test**: Reify a scope into a first-class value, pass it to a helper that expects stored scope behavior, and verify that containment queries, sibling queries, identity lookup, and element enumeration produce the same results as the original scope provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scope provider and its first-class representation of the same scope, **When** a developer queries either one for containment, siblings, lookup by identity, or all elements, **Then** both produce the same observable results.
+2. **Given** a helper that accepts a stored scope value rather than a direct scope provider, **When** the developer passes the first-class representation into that helper, **Then** the helper can perform the same scope-aware behavior without special-case code.
+
+---
+
+### Edge Cases
+
+- What happens when the chosen scope does not include parent or sibling information, as with a subtree-only scope? Scope queries that depend on unavailable information must return empty results rather than fail.
+- What happens when a lookup asks for an element identity that is not present in the current scope? The lookup must return no match and the operation must continue safely.
+- What happens when the caller chooses a scope boundary narrower than the full graph or document? The fold must respect that boundary and not infer a broader scope.
+- What happens when existing callers continue using `para` and `paraGraph` instead of the unified primitive? They must still receive the same behavior as before.
+- What happens when scope behavior is passed as a first-class value instead of a direct provider? The observable answers for the core scope queries must remain equivalent.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide one unified scope contract for structure-aware operations that defines containment queries, sibling queries, lookup by identity, and enumeration of all elements in scope.
+- **FR-002**: The system MUST provide one unified fold primitive for structure-aware operations that accepts an explicit scope and uses that scope consistently for the full duration of the fold.
+- **FR-003**: The unified fold MUST provide each fold step with the current element and the bottom-up results of that element's direct children.
+- **FR-004**: The scope boundary used by the unified fold MUST be determined by the containing context supplied by the caller, not inferred from the fold target alone.
+- **FR-005**: The existing `para` operation MUST remain available as a derived operation over the unified fold and MUST preserve its current observable behavior.
+- **FR-006**: The existing `paraGraph` operation MUST remain available as a derived operation over the unified fold and MUST preserve its current observable behavior.
+- **FR-007**: The system MUST provide a subtree-only scope suitable for `para`, limited to the folded subtree.
+- **FR-008**: In the subtree-only scope, queries that require unavailable parent or sibling context MUST return empty results rather than raise errors.
+- **FR-009**: The system MUST allow a scope provider to extend the unified scope model with additional context-specific queries without changing the shared fold contract.
+- **FR-010**: A developer MUST be able to use a new scope provider for a different containing context with the shared fold without introducing a new specialized fold primitive.
+- **FR-011**: The system MUST provide a first-class representation of scope behavior for cases where scope needs to be stored, passed dynamically, or composed outside direct polymorphic use.
+- **FR-012**: The first-class representation of scope MUST return the same observable results as its corresponding direct scope provider for containment, sibling lookup, identity lookup, and scope enumeration for at least the subtree-only scope and any graph-backed scope adapter introduced by this feature.
+- **FR-013**: The feature MUST be additive only: no existing public behavior may be removed or broken as part of this change.
+- **FR-014**: This feature MUST exclude broader cleanup work for other structure-aware operations unless they can be derived from the unified scope model without expanding the agreed scope of this feature.
+
+### Key Entities
+
+- **Unified Scope**: The definition of what elements are visible to a structure-aware operation. It supports containment queries, sibling queries, identity lookup, and complete enumeration of in-scope elements.
+- **Unified Scope-Aware Fold**: The shared fold behavior that processes a pattern bottom-up while consulting a single containing scope throughout the traversal.
+- **Subtree Scope**: The limited scope used for `para`, where the fold can inspect only the folded subtree and cannot rely on parent or sibling information.
+- **Graph-Wide Scope**: A richer scope used for graph-aware operations, where the fold can access graph-level context in addition to generic scope information.
+- **First-Class Scope Value**: A stored representation of scope behavior used when direct scope providers are inconvenient to pass or compose.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: All existing tests for `para` pass without modification after scope unification is introduced.
+- **SC-002**: All existing tests for `paraGraph` pass without modification after scope unification is introduced.
+- **SC-003**: Existing `para` and `paraGraph` call sites require zero code changes to preserve their prior observable behavior.
+- **SC-004**: At least one structure-aware fold written against the unified fold produces the same result as `para` on subtree-only input and the same result as `paraGraph` on graph-scoped input.
+- **SC-005**: A scope provider that lacks parent or sibling information returns empty results for those queries in 100% of tested cases, with no runtime failures.
+- **SC-006**: A first-class scope value and its corresponding direct scope provider return identical results for containment, sibling lookup, identity lookup, and all-elements enumeration in 100% of comparison tests.
+- **SC-007**: A developer can define and use an additional scope provider beyond the current graph-wide scope without adding another specialized fold primitive.
+
+## Assumptions
+
+- The current observable semantics of `para` and `paraGraph` are already correct and should be preserved exactly by this feature.
+- A subtree-only scope does not have enough information to answer parent or sibling questions, so empty results are the correct default behavior.
+- Broader unification of other structure-aware operations may follow later, but this feature is complete once the shared scope model and unified fold are in place.
+- Future scope providers may offer richer context than the generic scope contract, but the generic contract is the minimum shared behavior required for participation in the unified fold.

--- a/specs/038-scope-unification/tasks.md
+++ b/specs/038-scope-unification/tasks.md
@@ -1,0 +1,209 @@
+# Tasks: Scope Unification for Structure-Aware Operations
+
+**Input**: Design documents from `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/`  
+**Branch**: `038-scope-unification`  
+**Prerequisites**: `plan.md` ✓, `spec.md` ✓, `research.md` ✓, `data-model.md` ✓, `contracts/` ✓, `quickstart.md` ✓
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this belongs to (`US1`, `US2`, `US3`)
+- Every task includes exact file paths
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the current export surface, test touchpoints, and implementation files before changing the public fold APIs.
+
+- [ ] T001 Audit current exports and re-export touchpoints in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern.hs`, and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/pattern.cabal`
+- [ ] T002 Audit existing fold behavior and insertion points in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` so new scope-unification tests extend the current suites rather than replace them
+
+**Checkpoint**: Export and test touchpoints are confirmed. Foundational implementation can begin safely.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add the shared scope primitives and graph adapter scaffolding that all user stories depend on.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [ ] T003 Add subtree helper functions and public API declarations for `ScopeQuery`, `TrivialScope`, `trivialScope`, and `paraWithScope` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`
+- [ ] T004 Implement `ScopeQuery TrivialScope`, `paraWithScope`, and the `para` wrapper in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` so tree folds preserve bottom-up child-result order
+- [ ] T005 Add an internal `GraphView`-backed scope adapter scaffold and private indexing/helpers in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` without changing the public `GraphQuery(..)` record
+- [ ] T006 Align export lists for the new public generic scope APIs in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern.hs` while keeping the graph adapter internal
+
+**Checkpoint**: The shared scope primitive exists, `para` is backed by it, and graph-side adapter scaffolding is ready for story work.
+
+---
+
+## Phase 3: User Story 1 - Preserve existing fold behavior through one unified scope model (Priority: P1) 🎯 MVP
+
+**Goal**: Keep `para` and `paraGraph` behavior unchanged while introducing the shared scope model and wrapper-based implementation.
+
+**Independent Test**: Run the existing `para` and `paraGraph` suites without changing call sites or expectations; confirm the same observable results are produced.
+
+### Tests for User Story 1
+
+- [ ] T007 [US1] Add `TrivialScope` edge-case tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` asserting `containers` and `siblings` return `[]` and never fail for subtree-only scope
+- [ ] T008 [US1] Add `paraWithScope` compatibility tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering bottom-up child-result order and representative equivalence between `paraWithScope (trivialScope p)` and `para`
+- [ ] T009 [US1] Add QuickCheck property tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `paraWithScope (trivialScope p)` is observationally equivalent to `para` for representative generated `Pattern` values
+- [ ] T010 [P] [US1] Add wrapper-preservation tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering unchanged `paraGraph` and `paraGraphFixed` outputs under the unified scope implementation
+
+### Implementation for User Story 1
+
+- [ ] T011 [US1] Complete the internal graph adapter integration and update `paraGraph`, `paraGraphWithSeed`, and `paraGraphFixed` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` so they consume shared scope information while preserving `Map (Id v) r` output, `topoShapeSort`, and cycle soft-failure behavior
+- [ ] T012 [US1] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` for unchanged `para` and `paraGraph` behavior
+
+**Checkpoint**: `para` and `paraGraph` still work unchanged, and the shared scope model is now the internal foundation.
+
+---
+
+## Phase 4: User Story 2 - Add new scope-aware behavior without inventing new fold primitives (Priority: P2)
+
+**Goal**: Make the shared scope contract usable for new scope providers, including graph-wide generic scope answers via the internal `GraphView`-backed adapter.
+
+**Independent Test**: Define a non-graph scope provider that answers the generic scope questions, run `paraWithScope` against it, and confirm no new specialized fold primitive is needed.
+
+### Tests for User Story 2
+
+- [ ] T013 [P] [US2] Add custom-provider extensibility tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` by defining a local `ScopeQuery` instance and proving `paraWithScope` works without introducing another fold API
+- [ ] T014 [P] [US2] Add graph-boundary tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering `allElements`, `byIdentity`, `containers`, and `siblings` behavior for the internal `GraphView`-backed adapter inside a single `GraphView`
+
+### Implementation for User Story 2
+
+- [ ] T015 [US2] Implement the full internal `GraphView`-backed `ScopeQuery` adapter behavior in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, including fixed-scope `allElements`, scope-bounded identity lookup, direct-container lookup, and sibling derivation across classified graph elements
+- [ ] T016 [US2] Add Haddock guidance for implementing new scope providers and fixed-scope fold semantics in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`
+- [ ] T017 [US2] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate the extensibility and graph-boundary scenarios in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+
+**Checkpoint**: New scope providers can participate in the same fold model, and graph-wide generic scope answers are available without widening `GraphQuery(..)`.
+
+---
+
+## Phase 5: User Story 3 - Pass scope behavior around as data when needed (Priority: P3)
+
+**Goal**: Provide a first-class scope value that behaves the same as the original scope provider for generic scope operations.
+
+**Independent Test**: Reify a scope into a first-class value, pass it to a helper, and verify containment, sibling lookup, identity lookup, and enumeration match the original provider.
+
+### Tests for User Story 3
+
+- [ ] T018 [US3] Add `ScopeDict` observational-equivalence tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering containment, siblings, identity lookup, and all-elements enumeration for subtree scope
+- [ ] T019 [US3] Add QuickCheck property tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `toScopeDict` preserves `containers`, `siblings`, `byIdentity`, and `allElements` for representative subtree scope providers
+- [ ] T020 [P] [US3] Add graph-backed scope reification tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` proving a first-class scope value derived from the internal `GraphView`-backed adapter matches the direct adapter's generic scope answers
+- [ ] T021 [US3] Add higher-order helper tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving a reified scope value from `toScopeDict` can be passed as data without changing observable behavior
+
+### Implementation for User Story 3
+
+- [ ] T022 [US3] Implement `ScopeDict`, the `ScopeQuery ScopeDict` instance, and `toScopeDict` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`
+- [ ] T023 [US3] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate the `ScopeDict` scenarios in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+
+**Checkpoint**: Scope behavior can be stored and passed around as data without changing generic scope semantics.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Refresh reference documentation, complete source-level mathematical docs, and validate the full feature end to end.
+
+- [ ] T024 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/features/paramorphism.md` with the unified scope model, `paraWithScope`, and the relationship between `para` and `TrivialScope`
+- [ ] T025 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/features/para-graph.md` with the internal graph adapter mental model and the preserved `paraGraph` scheduling and cycle semantics
+- [ ] T026 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/PORTING-GUIDE.md` with the typeclass ↔ dictionary/value-form ↔ trait/protocol mapping for scope abstractions
+- [ ] T027 Update module-level and per-symbol documentation in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` so every new public type and function includes purpose, invariants, categorical meaning, and at least one usage example
+- [ ] T028 Validate `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/quickstart.md` against the implemented files and update any mismatched paths or verification steps in `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/quickstart.md`
+- [ ] T029 Validate by code review that no extra traversal or scheduling regression was introduced in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` against the preserved-asymptotics and single-pass constraints in `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/plan.md`
+- [ ] T030 Review `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, and related docs against `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/spec.md` to confirm no broader cleanup work was introduced beyond this feature's agreed scope
+- [ ] T031 Run `cabal build all` and `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to verify the full implementation and all scenarios covered by `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies; start immediately.
+- **Phase 2 (Foundational)**: Depends on Phase 1 and blocks all user story phases.
+- **Phase 3 (US1)**: Depends on Phase 2.
+- **Phase 4 (US2)**: Depends on Phase 2; it is independently testable once the shared scope primitives exist.
+- **Phase 5 (US3)**: Depends on Phase 2; it is independently testable once the shared scope contract exists.
+- **Phase 6 (Polish)**: Depends on all selected user stories being complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: First deliverable and recommended MVP.
+- **US2 (P2)**: Can start after Phase 2 and remains independently testable.
+- **US3 (P3)**: Can start after Phase 2 and remains independently testable.
+
+### Within Each User Story
+
+- Tests should be added before or alongside implementation and must fail meaningfully before the behavior is finalized.
+- Source implementation should precede the story validation command.
+- Each story is complete only after its independent test criteria pass.
+
+### Parallel Opportunities
+
+- T010 can run in parallel with T007-T009 after Phase 2.
+- T013 and T014 can run in parallel after Phase 2.
+- T020 can run in parallel with T018-T019 after Phase 2.
+- T024, T025, and T026 can run in parallel during the polish phase.
+
+---
+
+## Parallel Execution Examples
+
+### Parallel Example: User Story 1
+
+```text
+T010 in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
+while T007-T009 progress in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs
+```
+
+### Parallel Example: User Story 2
+
+```text
+T013 in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs
+T014 in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
+```
+
+### Parallel Example: User Story 3
+
+```text
+T020 in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
+while T018-T019 progress in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1.
+2. Complete Phase 2.
+3. Complete Phase 3.
+4. Stop and validate `para` and `paraGraph` compatibility before taking on extensibility or first-class dictionary support.
+
+### Incremental Delivery
+
+1. Setup + Foundational phases establish the shared scope primitive.
+2. User Story 1 delivers the highest-value behavior-preservation result.
+3. User Story 2 adds extensibility for new scope providers.
+4. User Story 3 adds the first-class value form for dynamic composition.
+5. Polish refreshes docs and validates the whole feature end to end.
+
+### Suggested MVP Scope
+
+- **MVP**: Phase 1 + Phase 2 + Phase 3 (`US1`)
+- **Why**: This delivers the core outcome of the feature: one unified scope model with zero regression for existing `para` and `paraGraph` callers.
+
+---
+
+## Notes
+
+- All task lines follow the required checklist format: checkbox, task ID, optional `[P]`, required story label for story tasks, and exact file paths.
+- The task list intentionally keeps `GraphQuery(..)` unchanged and routes generic graph scope through an internal `GraphView`-backed adapter, matching the planning decision in `research.md`.
+- QuickCheck property-test tasks are explicit because the constitution and plan require property-based verification where applicable.
+- The main executable validation commands are `cabal test pattern-test` and `cabal build all` from `/Users/akollegger/Developer/gram-data/pattern-hs`.

--- a/specs/038-scope-unification/tasks.md
+++ b/specs/038-scope-unification/tasks.md
@@ -18,8 +18,8 @@
 
 **Purpose**: Confirm the current export surface, test touchpoints, and implementation files before changing the public fold APIs.
 
-- [ ] T001 Audit current exports and re-export touchpoints in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern.hs`, and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/pattern.cabal`
-- [ ] T002 Audit existing fold behavior and insertion points in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` so new scope-unification tests extend the current suites rather than replace them
+- [X] T001 Audit current exports and re-export touchpoints in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern.hs`, and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/pattern.cabal`
+- [X] T002 Audit existing fold behavior and insertion points in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` so new scope-unification tests extend the current suites rather than replace them
 
 **Checkpoint**: Export and test touchpoints are confirmed. Foundational implementation can begin safely.
 
@@ -31,10 +31,10 @@
 
 **⚠️ CRITICAL**: No user story work should begin until this phase is complete.
 
-- [ ] T003 Add subtree helper functions and public API declarations for `ScopeQuery`, `TrivialScope`, `trivialScope`, and `paraWithScope` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`
-- [ ] T004 Implement `ScopeQuery TrivialScope`, `paraWithScope`, and the `para` wrapper in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` so tree folds preserve bottom-up child-result order
-- [ ] T005 Add an internal `GraphView`-backed scope adapter scaffold and private indexing/helpers in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` without changing the public `GraphQuery(..)` record
-- [ ] T006 Align export lists for the new public generic scope APIs in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern.hs` while keeping the graph adapter internal
+- [X] T003 Add subtree helper functions and public API declarations for `ScopeQuery`, `TrivialScope`, `trivialScope`, and `paraWithScope` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`
+- [X] T004 Implement `ScopeQuery TrivialScope`, `paraWithScope`, and the `para` wrapper in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` so tree folds preserve bottom-up child-result order
+- [X] T005 Add an internal `GraphView`-backed scope adapter scaffold and private indexing/helpers in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` without changing the public `GraphQuery(..)` record
+- [X] T006 Align export lists for the new public generic scope APIs in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern.hs` while keeping the graph adapter internal
 
 **Checkpoint**: The shared scope primitive exists, `para` is backed by it, and graph-side adapter scaffolding is ready for story work.
 
@@ -48,15 +48,15 @@
 
 ### Tests for User Story 1
 
-- [ ] T007 [US1] Add `TrivialScope` edge-case tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` asserting `containers` and `siblings` return `[]` and never fail for subtree-only scope
-- [ ] T008 [US1] Add `paraWithScope` compatibility tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering bottom-up child-result order and representative equivalence between `paraWithScope (trivialScope p)` and `para`
-- [ ] T009 [US1] Add QuickCheck property tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `paraWithScope (trivialScope p)` is observationally equivalent to `para` for representative generated `Pattern` values
-- [ ] T010 [P] [US1] Add wrapper-preservation tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering unchanged `paraGraph` and `paraGraphFixed` outputs under the unified scope implementation
+- [X] T007 [US1] Add `TrivialScope` edge-case tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` asserting `containers` and `siblings` return `[]` and never fail for subtree-only scope
+- [X] T008 [US1] Add `paraWithScope` compatibility tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering bottom-up child-result order and representative equivalence between `paraWithScope (trivialScope p)` and `para`
+- [X] T009 [US1] Add QuickCheck property tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `paraWithScope (trivialScope p)` is observationally equivalent to `para` for representative generated `Pattern` values
+- [X] T010 [P] [US1] Add wrapper-preservation tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering unchanged `paraGraph` and `paraGraphFixed` outputs under the unified scope implementation
 
 ### Implementation for User Story 1
 
-- [ ] T011 [US1] Complete the internal graph adapter integration and update `paraGraph`, `paraGraphWithSeed`, and `paraGraphFixed` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` so they consume shared scope information while preserving `Map (Id v) r` output, `topoShapeSort`, and cycle soft-failure behavior
-- [ ] T012 [US1] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` for unchanged `para` and `paraGraph` behavior
+- [X] T011 [US1] Complete the internal graph adapter integration and update `paraGraph`, `paraGraphWithSeed`, and `paraGraphFixed` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` so they consume shared scope information while preserving `Map (Id v) r` output, `topoShapeSort`, and cycle soft-failure behavior
+- [X] T012 [US1] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` for unchanged `para` and `paraGraph` behavior
 
 **Checkpoint**: `para` and `paraGraph` still work unchanged, and the shared scope model is now the internal foundation.
 
@@ -70,14 +70,14 @@
 
 ### Tests for User Story 2
 
-- [ ] T013 [P] [US2] Add custom-provider extensibility tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` by defining a local `ScopeQuery` instance and proving `paraWithScope` works without introducing another fold API
-- [ ] T014 [P] [US2] Add graph-boundary tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering `allElements`, `byIdentity`, `containers`, and `siblings` behavior for the internal `GraphView`-backed adapter inside a single `GraphView`
+- [X] T013 [P] [US2] Add custom-provider extensibility tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` by defining a local `ScopeQuery` instance and proving `paraWithScope` works without introducing another fold API
+- [X] T014 [P] [US2] Add graph-boundary tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering `allElements`, `byIdentity`, `containers`, and `siblings` behavior for the internal `GraphView`-backed adapter inside a single `GraphView`
 
 ### Implementation for User Story 2
 
-- [ ] T015 [US2] Implement the full internal `GraphView`-backed `ScopeQuery` adapter behavior in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, including fixed-scope `allElements`, scope-bounded identity lookup, direct-container lookup, and sibling derivation across classified graph elements
-- [ ] T016 [US2] Add Haddock guidance for implementing new scope providers and fixed-scope fold semantics in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`
-- [ ] T017 [US2] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate the extensibility and graph-boundary scenarios in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+- [X] T015 [US2] Implement the full internal `GraphView`-backed `ScopeQuery` adapter behavior in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, including fixed-scope `allElements`, scope-bounded identity lookup, direct-container lookup, and sibling derivation across classified graph elements
+- [X] T016 [US2] Add Haddock guidance for implementing new scope providers and fixed-scope fold semantics in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`
+- [X] T017 [US2] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate the extensibility and graph-boundary scenarios in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
 
 **Checkpoint**: New scope providers can participate in the same fold model, and graph-wide generic scope answers are available without widening `GraphQuery(..)`.
 
@@ -91,15 +91,15 @@
 
 ### Tests for User Story 3
 
-- [ ] T018 [US3] Add `ScopeDict` observational-equivalence tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering containment, siblings, identity lookup, and all-elements enumeration for subtree scope
-- [ ] T019 [US3] Add QuickCheck property tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `toScopeDict` preserves `containers`, `siblings`, `byIdentity`, and `allElements` for representative subtree scope providers
-- [ ] T020 [P] [US3] Add graph-backed scope reification tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` proving a first-class scope value derived from the internal `GraphView`-backed adapter matches the direct adapter's generic scope answers
-- [ ] T021 [US3] Add higher-order helper tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving a reified scope value from `toScopeDict` can be passed as data without changing observable behavior
+- [X] T018 [US3] Add `ScopeDict` observational-equivalence tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering containment, siblings, identity lookup, and all-elements enumeration for subtree scope
+- [X] T019 [US3] Add QuickCheck property tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `toScopeDict` preserves `containers`, `siblings`, `byIdentity`, and `allElements` for representative subtree scope providers
+- [X] T020 [P] [US3] Add graph-backed scope reification tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` proving a first-class scope value derived from the internal `GraphView`-backed adapter matches the direct adapter's generic scope answers
+- [X] T021 [US3] Add higher-order helper tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving a reified scope value from `toScopeDict` can be passed as data without changing observable behavior
 
 ### Implementation for User Story 3
 
-- [ ] T022 [US3] Implement `ScopeDict`, the `ScopeQuery ScopeDict` instance, and `toScopeDict` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`
-- [ ] T023 [US3] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate the `ScopeDict` scenarios in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+- [X] T022 [US3] Implement `ScopeDict`, the `ScopeQuery ScopeDict` instance, and `toScopeDict` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`
+- [X] T023 [US3] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate the `ScopeDict` scenarios in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
 
 **Checkpoint**: Scope behavior can be stored and passed around as data without changing generic scope semantics.
 
@@ -109,14 +109,14 @@
 
 **Purpose**: Refresh reference documentation, complete source-level mathematical docs, and validate the full feature end to end.
 
-- [ ] T024 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/features/paramorphism.md` with the unified scope model, `paraWithScope`, and the relationship between `para` and `TrivialScope`
-- [ ] T025 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/features/para-graph.md` with the internal graph adapter mental model and the preserved `paraGraph` scheduling and cycle semantics
-- [ ] T026 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/PORTING-GUIDE.md` with the typeclass ↔ dictionary/value-form ↔ trait/protocol mapping for scope abstractions
-- [ ] T027 Update module-level and per-symbol documentation in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` so every new public type and function includes purpose, invariants, categorical meaning, and at least one usage example
-- [ ] T028 Validate `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/quickstart.md` against the implemented files and update any mismatched paths or verification steps in `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/quickstart.md`
-- [ ] T029 Validate by code review that no extra traversal or scheduling regression was introduced in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` against the preserved-asymptotics and single-pass constraints in `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/plan.md`
-- [ ] T030 Review `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, and related docs against `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/spec.md` to confirm no broader cleanup work was introduced beyond this feature's agreed scope
-- [ ] T031 Run `cabal build all` and `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to verify the full implementation and all scenarios covered by `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+- [X] T024 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/features/paramorphism.md` with the unified scope model, `paraWithScope`, and the relationship between `para` and `TrivialScope`
+- [X] T025 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/features/para-graph.md` with the internal graph adapter mental model and the preserved `paraGraph` scheduling and cycle semantics
+- [X] T026 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/PORTING-GUIDE.md` with the typeclass ↔ dictionary/value-form ↔ trait/protocol mapping for scope abstractions
+- [X] T027 Update module-level and per-symbol documentation in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` so every new public type and function includes purpose, invariants, categorical meaning, and at least one usage example
+- [X] T028 Validate `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/quickstart.md` against the implemented files and update any mismatched paths or verification steps in `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/quickstart.md`
+- [X] T029 Validate by code review that no extra traversal or scheduling regression was introduced in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` against the preserved-asymptotics and single-pass constraints in `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/plan.md`
+- [X] T030 Review `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, and related docs against `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/spec.md` to confirm no broader cleanup work was introduced beyond this feature's agreed scope
+- [X] T031 Run `cabal build all` and `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to verify the full implementation and all scenarios covered by `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
 
 ---
 

--- a/specs/038-scope-unification/tasks.md
+++ b/specs/038-scope-unification/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: Scope Unification for Structure-Aware Operations
 
-**Input**: Design documents from `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/`  
+**Input**: Design documents from `specs/038-scope-unification/`  
 **Branch**: `038-scope-unification`  
 **Prerequisites**: `plan.md` ✓, `spec.md` ✓, `research.md` ✓, `data-model.md` ✓, `contracts/` ✓, `quickstart.md` ✓
 
@@ -18,8 +18,8 @@
 
 **Purpose**: Confirm the current export surface, test touchpoints, and implementation files before changing the public fold APIs.
 
-- [X] T001 Audit current exports and re-export touchpoints in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern.hs`, and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/pattern.cabal`
-- [X] T002 Audit existing fold behavior and insertion points in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` so new scope-unification tests extend the current suites rather than replace them
+- [X] T001 Audit current exports and re-export touchpoints in `libs/pattern/src/Pattern/Core.hs`, `libs/pattern/src/Pattern/Graph/Transform.hs`, `libs/pattern/src/Pattern/Graph.hs`, `libs/pattern/src/Pattern.hs`, and `libs/pattern/pattern.cabal`
+- [X] T002 Audit existing fold behavior and insertion points in `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` so new scope-unification tests extend the current suites rather than replace them
 
 **Checkpoint**: Export and test touchpoints are confirmed. Foundational implementation can begin safely.
 
@@ -31,10 +31,10 @@
 
 **⚠️ CRITICAL**: No user story work should begin until this phase is complete.
 
-- [X] T003 Add subtree helper functions and public API declarations for `ScopeQuery`, `TrivialScope`, `trivialScope`, and `paraWithScope` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`
-- [X] T004 Implement `ScopeQuery TrivialScope`, `paraWithScope`, and the `para` wrapper in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` so tree folds preserve bottom-up child-result order
-- [X] T005 Add an internal `GraphView`-backed scope adapter scaffold and private indexing/helpers in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` without changing the public `GraphQuery(..)` record
-- [X] T006 Align export lists for the new public generic scope APIs in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern.hs` while keeping the graph adapter internal
+- [X] T003 Add subtree helper functions and public API declarations for `ScopeQuery`, `TrivialScope`, `trivialScope`, and `paraWithScope` in `libs/pattern/src/Pattern/Core.hs`
+- [X] T004 Implement `ScopeQuery TrivialScope`, `paraWithScope`, and the `para` wrapper in `libs/pattern/src/Pattern/Core.hs` so tree folds preserve bottom-up child-result order
+- [X] T005 Add an internal `GraphView`-backed scope adapter scaffold and private indexing/helpers in `libs/pattern/src/Pattern/Graph/Transform.hs` without changing the public `GraphQuery(..)` record
+- [X] T006 Align export lists for the new public generic scope APIs in `libs/pattern/src/Pattern/Core.hs` and `libs/pattern/src/Pattern.hs` while keeping the graph adapter internal
 
 **Checkpoint**: The shared scope primitive exists, `para` is backed by it, and graph-side adapter scaffolding is ready for story work.
 
@@ -48,15 +48,15 @@
 
 ### Tests for User Story 1
 
-- [X] T007 [US1] Add `TrivialScope` edge-case tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` asserting `containers` and `siblings` return `[]` and never fail for subtree-only scope
-- [X] T008 [US1] Add `paraWithScope` compatibility tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering bottom-up child-result order and representative equivalence between `paraWithScope (trivialScope p)` and `para`
-- [X] T009 [US1] Add QuickCheck property tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `paraWithScope (trivialScope p)` is observationally equivalent to `para` for representative generated `Pattern` values
-- [X] T010 [P] [US1] Add wrapper-preservation tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering unchanged `paraGraph` and `paraGraphFixed` outputs under the unified scope implementation
+- [X] T007 [US1] Add `TrivialScope` edge-case tests to `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` asserting `containers` and `siblings` return `[]` and never fail for subtree-only scope
+- [X] T008 [US1] Add `paraWithScope` compatibility tests to `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering bottom-up child-result order and representative equivalence between `paraWithScope (trivialScope p)` and `para`
+- [X] T009 [US1] Add QuickCheck property tests to `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `paraWithScope (trivialScope p)` is observationally equivalent to `para` for representative generated `Pattern` values
+- [X] T010 [P] [US1] Add wrapper-preservation tests to `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering unchanged `paraGraph` and `paraGraphFixed` outputs under the unified scope implementation
 
 ### Implementation for User Story 1
 
-- [X] T011 [US1] Complete the internal graph adapter integration and update `paraGraph`, `paraGraphWithSeed`, and `paraGraphFixed` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` so they consume shared scope information while preserving `Map (Id v) r` output, `topoShapeSort`, and cycle soft-failure behavior
-- [X] T012 [US1] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` for unchanged `para` and `paraGraph` behavior
+- [X] T011 [US1] Complete the internal graph adapter integration and update `paraGraph`, `paraGraphWithSeed`, and `paraGraphFixed` in `libs/pattern/src/Pattern/Graph/Transform.hs` so they consume shared scope information while preserving `Map (Id v) r` output, `topoShapeSort`, and cycle soft-failure behavior
+- [X] T012 [US1] Run `cabal test pattern-test` from the repo root to validate `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` for unchanged `para` and `paraGraph` behavior
 
 **Checkpoint**: `para` and `paraGraph` still work unchanged, and the shared scope model is now the internal foundation.
 
@@ -70,14 +70,14 @@
 
 ### Tests for User Story 2
 
-- [X] T013 [P] [US2] Add custom-provider extensibility tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` by defining a local `ScopeQuery` instance and proving `paraWithScope` works without introducing another fold API
-- [X] T014 [P] [US2] Add graph-boundary tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering `allElements`, `byIdentity`, `containers`, and `siblings` behavior for the internal `GraphView`-backed adapter inside a single `GraphView`
+- [X] T013 [P] [US2] Add custom-provider extensibility tests to `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` by defining a local `ScopeQuery` instance and proving `paraWithScope` works without introducing another fold API
+- [X] T014 [P] [US2] Add graph-boundary tests to `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` covering `allElements`, `byIdentity`, `containers`, and `siblings` behavior for the internal `GraphView`-backed adapter inside a single `GraphView`
 
 ### Implementation for User Story 2
 
-- [X] T015 [US2] Implement the full internal `GraphView`-backed `ScopeQuery` adapter behavior in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, including fixed-scope `allElements`, scope-bounded identity lookup, direct-container lookup, and sibling derivation across classified graph elements
-- [X] T016 [US2] Add Haddock guidance for implementing new scope providers and fixed-scope fold semantics in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`
-- [X] T017 [US2] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate the extensibility and graph-boundary scenarios in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+- [X] T015 [US2] Implement the full internal `GraphView`-backed `ScopeQuery` adapter behavior in `libs/pattern/src/Pattern/Graph/Transform.hs`, including fixed-scope `allElements`, scope-bounded identity lookup, direct-container lookup, and sibling derivation across classified graph elements
+- [X] T016 [US2] Add Haddock guidance for implementing new scope providers and fixed-scope fold semantics in `libs/pattern/src/Pattern/Core.hs` and `libs/pattern/src/Pattern/Graph/Transform.hs`
+- [X] T017 [US2] Run `cabal test pattern-test` from the repo root to validate the extensibility and graph-boundary scenarios in `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
 
 **Checkpoint**: New scope providers can participate in the same fold model, and graph-wide generic scope answers are available without widening `GraphQuery(..)`.
 
@@ -91,15 +91,15 @@
 
 ### Tests for User Story 3
 
-- [X] T018 [US3] Add `ScopeDict` observational-equivalence tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering containment, siblings, identity lookup, and all-elements enumeration for subtree scope
-- [X] T019 [US3] Add QuickCheck property tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `toScopeDict` preserves `containers`, `siblings`, `byIdentity`, and `allElements` for representative subtree scope providers
-- [X] T020 [P] [US3] Add graph-backed scope reification tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` proving a first-class scope value derived from the internal `GraphView`-backed adapter matches the direct adapter's generic scope answers
-- [X] T021 [US3] Add higher-order helper tests to `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving a reified scope value from `toScopeDict` can be passed as data without changing observable behavior
+- [X] T018 [US3] Add `ScopeDict` observational-equivalence tests to `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` covering containment, siblings, identity lookup, and all-elements enumeration for subtree scope
+- [X] T019 [US3] Add QuickCheck property tests to `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving `toScopeDict` preserves `containers`, `siblings`, `byIdentity`, and `allElements` for representative subtree scope providers
+- [X] T020 [P] [US3] Add graph-backed scope reification tests to `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs` proving a first-class scope value derived from the internal `GraphView`-backed adapter matches the direct adapter's generic scope answers
+- [X] T021 [US3] Add higher-order helper tests to `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` proving a reified scope value from `toScopeDict` can be passed as data without changing observable behavior
 
 ### Implementation for User Story 3
 
-- [X] T022 [US3] Implement `ScopeDict`, the `ScopeQuery ScopeDict` instance, and `toScopeDict` in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`
-- [X] T023 [US3] Run `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to validate the `ScopeDict` scenarios in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+- [X] T022 [US3] Implement `ScopeDict`, the `ScopeQuery ScopeDict` instance, and `toScopeDict` in `libs/pattern/src/Pattern/Core.hs`
+- [X] T023 [US3] Run `cabal test pattern-test` from the repo root to validate the `ScopeDict` scenarios in `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
 
 **Checkpoint**: Scope behavior can be stored and passed around as data without changing generic scope semantics.
 
@@ -109,14 +109,14 @@
 
 **Purpose**: Refresh reference documentation, complete source-level mathematical docs, and validate the full feature end to end.
 
-- [X] T024 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/features/paramorphism.md` with the unified scope model, `paraWithScope`, and the relationship between `para` and `TrivialScope`
-- [X] T025 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/features/para-graph.md` with the internal graph adapter mental model and the preserved `paraGraph` scheduling and cycle semantics
-- [X] T026 [P] Update `/Users/akollegger/Developer/gram-data/pattern-hs/docs/reference/PORTING-GUIDE.md` with the typeclass ↔ dictionary/value-form ↔ trait/protocol mapping for scope abstractions
-- [X] T027 Update module-level and per-symbol documentation in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` so every new public type and function includes purpose, invariants, categorical meaning, and at least one usage example
-- [X] T028 Validate `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/quickstart.md` against the implemented files and update any mismatched paths or verification steps in `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/quickstart.md`
-- [X] T029 Validate by code review that no extra traversal or scheduling regression was introduced in `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs` against the preserved-asymptotics and single-pass constraints in `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/plan.md`
-- [X] T030 Review `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Core.hs`, `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/src/Pattern/Graph/Transform.hs`, and related docs against `/Users/akollegger/Developer/gram-data/pattern-hs/specs/038-scope-unification/spec.md` to confirm no broader cleanup work was introduced beyond this feature's agreed scope
-- [X] T031 Run `cabal build all` and `cabal test pattern-test` from `/Users/akollegger/Developer/gram-data/pattern-hs` to verify the full implementation and all scenarios covered by `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `/Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
+- [X] T024 [P] Update `docs/reference/features/paramorphism.md` with the unified scope model, `paraWithScope`, and the relationship between `para` and `TrivialScope`
+- [X] T025 [P] Update `docs/reference/features/para-graph.md` with the internal graph adapter mental model and the preserved `paraGraph` scheduling and cycle semantics
+- [X] T026 [P] Update `docs/reference/PORTING-GUIDE.md` with the typeclass ↔ dictionary/value-form ↔ trait/protocol mapping for scope abstractions
+- [X] T027 Update module-level and per-symbol documentation in `libs/pattern/src/Pattern/Core.hs` and `libs/pattern/src/Pattern/Graph/Transform.hs` so every new public type and function includes purpose, invariants, categorical meaning, and at least one usage example
+- [X] T028 Validate `specs/038-scope-unification/quickstart.md` against the implemented files and update any mismatched paths or verification steps in `specs/038-scope-unification/quickstart.md`
+- [X] T029 Validate by code review that no extra traversal or scheduling regression was introduced in `libs/pattern/src/Pattern/Core.hs` and `libs/pattern/src/Pattern/Graph/Transform.hs` against the preserved-asymptotics and single-pass constraints in `specs/038-scope-unification/plan.md`
+- [X] T030 Review `libs/pattern/src/Pattern/Core.hs`, `libs/pattern/src/Pattern/Graph/Transform.hs`, and related docs against `specs/038-scope-unification/spec.md` to confirm no broader cleanup work was introduced beyond this feature's agreed scope
+- [X] T031 Run `cabal build all` and `cabal test pattern-test` from the repo root to verify the full implementation and all scenarios covered by `libs/pattern/tests/Spec/Pattern/CoreSpec.hs` and `libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs`
 
 ---
 
@@ -157,22 +157,22 @@
 ### Parallel Example: User Story 1
 
 ```text
-T010 in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
-while T007-T009 progress in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs
+T010 in libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
+while T007-T009 progress in libs/pattern/tests/Spec/Pattern/CoreSpec.hs
 ```
 
 ### Parallel Example: User Story 2
 
 ```text
-T013 in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs
-T014 in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
+T013 in libs/pattern/tests/Spec/Pattern/CoreSpec.hs
+T014 in libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
 ```
 
 ### Parallel Example: User Story 3
 
 ```text
-T020 in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
-while T018-T019 progress in /Users/akollegger/Developer/gram-data/pattern-hs/libs/pattern/tests/Spec/Pattern/CoreSpec.hs
+T020 in libs/pattern/tests/Spec/Pattern/Graph/TransformSpec.hs
+while T018-T019 progress in libs/pattern/tests/Spec/Pattern/CoreSpec.hs
 ```
 
 ---
@@ -206,4 +206,4 @@ while T018-T019 progress in /Users/akollegger/Developer/gram-data/pattern-hs/lib
 - All task lines follow the required checklist format: checkbox, task ID, optional `[P]`, required story label for story tasks, and exact file paths.
 - The task list intentionally keeps `GraphQuery(..)` unchanged and routes generic graph scope through an internal `GraphView`-backed adapter, matching the planning decision in `research.md`.
 - QuickCheck property-test tasks are explicit because the constitution and plan require property-based verification where applicable.
-- The main executable validation commands are `cabal test pattern-test` and `cabal build all` from `/Users/akollegger/Developer/gram-data/pattern-hs`.
+- The main executable validation commands are `cabal test pattern-test` and `cabal build all` from the repo root.


### PR DESCRIPTION
This pull request introduces a unified and extensible scope abstraction for structure-aware folds in the Pattern library, generalizing paramorphism (`para`) to support both tree and graph contexts under a common interface. The changes add new typeclasses and data types (`ScopeQuery`, `TrivialScope`, `ScopeDict`), provide a new generic fold primitive (`paraWithScope`), and update documentation throughout the codebase and guides to reflect the new model and its recommended usage in ports to other languages. Backward compatibility is preserved: the classic `para` API and behavior remain unchanged, but are now implemented in terms of the new primitives.

**Key changes:**

### Core Library API and Implementation

* Introduced the `ScopeQuery` typeclass, the `TrivialScope` data type for subtree-only scopes, the `ScopeDict` value-form for first-class scope providers, and the `paraWithScope` function for explicit, scope-aware folding. The classic `para` is now a wrapper over `paraWithScope` with `TrivialScope` for backward compatibility. (`libs/pattern/src/Pattern/Core.hs`, `Pattern.hs`) [[1]](diffhunk://#diff-aecd84bbd962967500f9ddb3f624fa9fc3f940654b7fe74fcfb284b1a23dcce9R2-R4) [[2]](diffhunk://#diff-aecd84bbd962967500f9ddb3f624fa9fc3f940654b7fe74fcfb284b1a23dcce9R36-R41) [[3]](diffhunk://#diff-aecd84bbd962967500f9ddb3f624fa9fc3f940654b7fe74fcfb284b1a23dcce9R1152-R1302) [[4]](diffhunk://#diff-aecd84bbd962967500f9ddb3f624fa9fc3f940654b7fe74fcfb284b1a23dcce9L1191-R1351) [[5]](diffhunk://#diff-160111770122c0ca13923296666ffeb19573710cbce0b7ddcd835dc0fc5b66b3L13-R14) [[6]](diffhunk://#diff-160111770122c0ca13923296666ffeb19573710cbce0b7ddcd835dc0fc5b66b3L22-R24)

### Documentation: Reference and Porting Guides

* Updated the Porting Guide to describe the new scope abstraction, mapping strategies for other languages, and the relationship between `ScopeQuery`, `ScopeDict`, and classic paramorphism. Clarified the recommended implementation order and tree/graph fold distinctions. (`docs/reference/PORTING-GUIDE.md`) [[1]](diffhunk://#diff-27e0d26bd3a65c254bf04a5b4d20caa9a1c40413e537bdffe289894ccaf2e329R10-R27) [[2]](diffhunk://#diff-27e0d26bd3a65c254bf04a5b4d20caa9a1c40413e537bdffe289894ccaf2e329L44-R66) [[3]](diffhunk://#diff-27e0d26bd3a65c254bf04a5b4d20caa9a1c40413e537bdffe289894ccaf2e329L392-R435) [[4]](diffhunk://#diff-27e0d26bd3a65c254bf04a5b4d20caa9a1c40413e537bdffe289894ccaf2e329L410-R458)
* Overhauled the paramorphism documentation to explain the unified scope model, new API, and usage patterns for both tree and graph folds. (`docs/reference/features/paramorphism.md`) [[1]](diffhunk://#diff-7f33893ee6c8542253a3bf580d613522503dd29c7ac4aa71f4e9b78db128745fL8-R64) [[2]](diffhunk://#diff-7f33893ee6c8542253a3bf580d613522503dd29c7ac4aa71f4e9b78db128745fL18-R74) [[3]](diffhunk://#diff-7f33893ee6c8542253a3bf580d613522503dd29c7ac4aa71f4e9b78db128745fL43-R108) [[4]](diffhunk://#diff-7f33893ee6c8542253a3bf580d613522503dd29c7ac4aa71f4e9b78db128745fL151-R218) [[5]](diffhunk://#diff-7f33893ee6c8542253a3bf580d613522503dd29c7ac4aa71f4e9b78db128745fR311)
* Updated the `paraGraph` documentation to clarify its role as a graph-scoped fold under the new scope model and to document the new internal helper for deriving a `ScopeDict` from a `GraphView`. (`docs/reference/features/para-graph.md`) [[1]](diffhunk://#diff-8c0538868b27b36413965e5a749e7a868a3b690749467b299af138a428d42610L8-R17) [[2]](diffhunk://#diff-8c0538868b27b36413965e5a749e7a868a3b690749467b299af138a428d42610R37-R53) [[3]](diffhunk://#diff-8c0538868b27b36413965e5a749e7a868a3b690749467b299af138a428d42610R225)

### Rules and Feature Plan Updates

* Added feature plan and test rules for the new scope unification feature, documenting its Haskell implementation and in-memory semantics. (`.cursor/rules/specify-rules.mdc`) [[1]](diffhunk://#diff-7a9187c906dc1fdaed6cbd116594eb056938302315c16b81ed8f76b86c3b6f51R45-R46) [[2]](diffhunk://#diff-7a9187c906dc1fdaed6cbd116594eb056938302315c16b81ed8f76b86c3b6f51R66-L66)

These changes lay the groundwork for more powerful, extensible, and portable structure-aware folds, while keeping the existing API stable for current users.