### PR TITLE
039 representation map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@ Auto-generated from all feature plans. Last updated: 2026-01-23
 ## Active Technologies
 - Haskell (GHC 9.12.2) + `Data.Map.Strict`, `Data.List (foldl')`, `Data.Maybe (mapMaybe)` — all already imported in Transform.hs (037-topo-shape-sort)
 - N/A — pure in-memory algorithm (037-topo-shape-sort)
+- Haskell (GHC 9.12.2) + base, containers — no new dependencies required (039-representation-map)
+- N/A — pure in-memory types (039-representation-map)
 
 - Haskell (GHC 9.12.2) (031-pattern-reconciliation)
 
@@ -24,6 +26,7 @@ tests/
 Haskell (GHC 9.12.2): Follow standard conventions
 
 ## Recent Changes
+- 039-representation-map: Added Haskell (GHC 9.12.2) + base, containers — no new dependencies required
 - 037-topo-shape-sort: Added Haskell (GHC 9.12.2) + `Data.Map.Strict`, `Data.List (foldl')`, `Data.Maybe (mapMaybe)` — all already imported in Transform.hs
 
 - 031-pattern-reconciliation: Added Haskell (GHC 9.12.2)

--- a/cabal.project
+++ b/cabal.project
@@ -8,5 +8,8 @@ packages:
   libs/gram/
   apps/gramref-cli/
 
+package pattern
+  tests: True
+
 -- Use GHC 9.12.2 (latest stable version with good tooling support)
 with-compiler: ghc-9.12.2

--- a/libs/pattern/pattern.cabal
+++ b/libs/pattern/pattern.cabal
@@ -23,6 +23,7 @@ library
     exposed-modules:
         Pattern
         Pattern.Core
+        Pattern.RepresentationMap
         Pattern.Graph
         Pattern.Graph.GraphClassifier
         Pattern.Graph.GraphQuery
@@ -59,6 +60,7 @@ test-suite pattern-test
         Spec.Pattern.PatternGraphProperties
         Spec.Pattern.PatternGraphSpec
         Spec.Pattern.Properties
+        Spec.Pattern.RepresentationMapSpec
         Spec.Pattern.ReconcileSpec
         Spec.Pattern.ReconcileProperties
 

--- a/libs/pattern/src/Pattern.hs
+++ b/libs/pattern/src/Pattern.hs
@@ -70,6 +70,8 @@
 module Pattern
   ( -- * Core Pattern Type and Operations
     module Pattern.Core
+    -- * Representation Maps
+  , module Pattern.RepresentationMap
     -- * Graph Operations and GraphView
   , module Pattern.Graph
     -- * Portable Graph Query Interface
@@ -89,6 +91,7 @@ module Pattern
   ) where
 
 import Pattern.Core
+import Pattern.RepresentationMap
 import Pattern.Graph
 import Pattern.Graph.GraphQuery
 import Pattern.Graph.Transform

--- a/libs/pattern/src/Pattern/Core.hs
+++ b/libs/pattern/src/Pattern/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -32,6 +33,9 @@ module Pattern.Core
   , depthAt
   , sizeAt
   , indicesAt
+    -- * Shape Kinds
+  , PatternKind(..)
+  , checkKind
     -- * Paramorphism Functions
   , ScopeQuery(..)
   , TrivialScope
@@ -1186,6 +1190,38 @@ class ScopeQuery q v where
 
   -- | Enumerate every element in scope.
   allElements :: q v -> [Pattern v]
+
+-- | A named, scope-aware description of a family of pattern shapes.
+--
+-- A 'PatternKind' acts like a subobject classifier for 'Pattern': it names a
+-- recognizable subtype via a predicate rather than by introducing a new data
+-- type. The canonical example witnesses that the kind is inhabited.
+--
+-- Invariant:
+--
+-- * For any valid scope @q@, @kindPred k q (kindExample k) == True@.
+data PatternKind v = PatternKind
+  { kindName :: String
+    -- ^ Unique human-readable name for the kind.
+    -- Used for diagnostics and runtime compatibility checks during map composition.
+  , kindPred :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ Membership predicate for the kind.
+    -- Structural kinds may ignore the scope argument; scope-relative kinds can
+    -- inspect 'containers', 'siblings', 'byIdentity', or 'allElements'.
+  , kindExample :: Pattern v
+    -- ^ Canonical example inhabiting the kind.
+    -- Useful for smoke tests, documentation, and generator seeds.
+  }
+
+-- | Check whether a pattern belongs to a named kind within a scope.
+--
+-- This is the direct convenience wrapper over 'kindPred'.
+--
+-- Categorical note: 'kindPred' is the characteristic morphism for the
+-- subobject named by the 'PatternKind'; 'checkKind' applies that morphism at a
+-- concrete scope and pattern.
+checkKind :: ScopeQuery q v => PatternKind v -> q v -> Pattern v -> Bool
+checkKind k q p = kindPred k q p
 
 -- | The subtree-only scope used by 'para'.
 --

--- a/libs/pattern/src/Pattern/RepresentationMap.hs
+++ b/libs/pattern/src/Pattern/RepresentationMap.hs
@@ -35,17 +35,17 @@ import Pattern.Core (Pattern, PatternKind, ScopeQuery, kindName)
 --   are deferred; for now those details live in documentation and tests next to
 --   concrete maps.
 data RepresentationMap v = RepresentationMap
-  { name :: String
+  { repMapName :: String
     -- ^ Unique human-readable name for the map.
-  , domain :: PatternKind v
+  , repMapDomain :: PatternKind v
     -- ^ Source kind. 'forward' is intended for patterns of this kind.
-  , codomain :: PatternKind v
+  , repMapCodomain :: PatternKind v
     -- ^ Target kind. 'forward' should produce patterns of this kind.
-  , forward :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , repMapForward :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
     -- ^ Domain-to-codomain transform, polymorphic over any valid scope.
-  , inverse :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , repMapInverse :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
     -- ^ Codomain-to-domain transform, polymorphic over any valid scope.
-  , roundTrip :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+  , repMapRoundTrip :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
     -- ^ Isomorphism witness for domain-kind inputs at a given scope.
   }
 
@@ -61,19 +61,20 @@ data RepresentationMap v = RepresentationMap
 -- objects are 'PatternKind's and whose isomorphisms are 'RepresentationMap's.
 compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)
 compose m1 m2
-  | kindName (codomain m1) /= kindName (domain m2) =
+  | kindName (repMapCodomain m1) /= kindName (repMapDomain m2) =
       Left $
-        "compose: codomain of '" <> name m1
-          <> "' (" <> kindName (codomain m1)
-          <> ") does not match domain of '" <> name m2
-          <> "' (" <> kindName (domain m2) <> ")"
+        "compose: codomain of '" <> repMapName m1
+          <> "' (" <> kindName (repMapCodomain m1)
+          <> ") does not match domain of '" <> repMapName m2
+          <> "' (" <> kindName (repMapDomain m2) <> ")"
   | otherwise =
       Right
         RepresentationMap
-          { name = name m1 <> " >>> " <> name m2
-          , domain = domain m1
-          , codomain = codomain m2
-          , forward = \q p -> forward m2 q (forward m1 q p)
-          , inverse = \q p -> inverse m1 q (inverse m2 q p)
-          , roundTrip = \q p -> roundTrip m1 q p && roundTrip m2 q (forward m1 q p)
+          { repMapName = repMapName m1 <> " >>> " <> repMapName m2
+          , repMapDomain = repMapDomain m1
+          , repMapCodomain = repMapCodomain m2
+          , repMapForward = \q p -> repMapForward m2 q (repMapForward m1 q p)
+          , repMapInverse = \q p -> repMapInverse m1 q (repMapInverse m2 q p)
+          , repMapRoundTrip =
+              \q p -> repMapRoundTrip m1 q p && repMapRoundTrip m2 q (repMapForward m1 q p)
           }

--- a/libs/pattern/src/Pattern/RepresentationMap.hs
+++ b/libs/pattern/src/Pattern/RepresentationMap.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE RankNTypes #-}
+-- | Invertible mappings between named pattern kinds.
+--
+-- A 'RepresentationMap' names a pair of compatible structural transforms between
+-- two 'PatternKind's. The map itself carries only executable behavior and its
+-- round-trip witness. Explanatory metadata about how a map works is deferred for
+-- a later design that can express declarative, checkable claims rather than
+-- inline prose attached to the value.
+module Pattern.RepresentationMap
+  ( RepresentationMap(..)
+  , compose
+  )
+where
+
+import Pattern.Core (Pattern, PatternKind, ScopeQuery, kindName)
+
+-- | A named, invertible mapping between two pattern kinds.
+--
+-- A 'RepresentationMap' is the executable form of an isomorphism between named
+-- shapes. 'forward' and 'inverse' are the two morphism components, while
+-- 'roundTrip' is the machine-checkable witness that the mapping preserves
+-- information on the domain kind.
+--
+-- Invariants for domain-kind inputs:
+--
+-- * 'forward' should produce a pattern accepted by 'codomain'.
+-- * 'roundTrip' should hold.
+-- * When 'roundTrip' holds, @(inverse m q . forward m q) p == p@ structurally.
+--
+-- Notes:
+--
+-- * Scope remains polymorphic, so maps are not tied to a particular backing
+--   representation.
+-- * Declarative, machine-checkable claims about map-specific encoding choices
+--   are deferred; for now those details live in documentation and tests next to
+--   concrete maps.
+data RepresentationMap v = RepresentationMap
+  { name :: String
+    -- ^ Unique human-readable name for the map.
+  , domain :: PatternKind v
+    -- ^ Source kind. 'forward' is intended for patterns of this kind.
+  , codomain :: PatternKind v
+    -- ^ Target kind. 'forward' should produce patterns of this kind.
+  , forward :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+    -- ^ Domain-to-codomain transform, polymorphic over any valid scope.
+  , inverse :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+    -- ^ Codomain-to-domain transform, polymorphic over any valid scope.
+  , roundTrip :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ Isomorphism witness for domain-kind inputs at a given scope.
+  }
+
+-- | Compose two compatible representation maps.
+--
+-- Composition is defined only when the codomain kind of the first map has the
+-- same 'kindName' as the domain kind of the second. The resulting map keeps
+-- the first domain, the second codomain, composes 'forward' left-to-right,
+-- composes 'inverse' right-to-left, and preserves round-trip validation in the
+-- same order.
+--
+-- Categorical note: this is morphism composition for the category whose
+-- objects are 'PatternKind's and whose isomorphisms are 'RepresentationMap's.
+compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)
+compose m1 m2
+  | kindName (codomain m1) /= kindName (domain m2) =
+      Left $
+        "compose: codomain of '" <> name m1
+          <> "' (" <> kindName (codomain m1)
+          <> ") does not match domain of '" <> name m2
+          <> "' (" <> kindName (domain m2) <> ")"
+  | otherwise =
+      Right
+        RepresentationMap
+          { name = name m1 <> " >>> " <> name m2
+          , domain = domain m1
+          , codomain = codomain m2
+          , forward = \q p -> forward m2 q (forward m1 q p)
+          , inverse = \q p -> inverse m1 q (inverse m2 q p)
+          , roundTrip = \q p -> roundTrip m1 q p && roundTrip m2 q (forward m1 q p)
+          }

--- a/libs/pattern/tests/Spec/Pattern/RepresentationMapSpec.hs
+++ b/libs/pattern/tests/Spec/Pattern/RepresentationMapSpec.hs
@@ -13,7 +13,7 @@ import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldConta
 import Subject.Core (Subject(..), Symbol(..))
 import qualified Subject.Core as Subj
 import Subject.Value (Value(..))
-import Test.QuickCheck (Property, property)
+import Test.QuickCheck (property)
 import qualified Test.QuickCheck as QC
 
 newtype VisibleScope v = VisibleScope [Pattern v]
@@ -85,41 +85,44 @@ aliasedWrappedPatternKind = PatternKind
 
 wrapLeafMap :: RepresentationMap String
 wrapLeafMap = RepresentationMap
-  { name = "wrapLeaf"
-  , domain = leafPatternKind
-  , codomain = wrappedPatternKind
-  , forward = \_ p -> Pattern "wrapped" [p]
-  , inverse = \_ p ->
+  { repMapName = "wrapLeaf"
+  , repMapDomain = leafPatternKind
+  , repMapCodomain = wrappedPatternKind
+  , repMapForward = \_ p -> Pattern "wrapped" [p]
+  , repMapInverse = \_ p ->
       case p of
         Pattern "wrapped" [child] -> child
         _ -> p
-  , roundTrip = \q p -> (inverse wrapLeafMap q . forward wrapLeafMap q) p == p
+  , repMapRoundTrip =
+      \q p -> (repMapInverse wrapLeafMap q . repMapForward wrapLeafMap q) p == p
   }
 
 boxWrappedMap :: RepresentationMap String
 boxWrappedMap = RepresentationMap
-  { name = "boxWrapped"
-  , domain = wrappedPatternKind
-  , codomain = boxedPatternKind
-  , forward = \_ p -> Pattern "boxed" [p]
-  , inverse = \_ p ->
+  { repMapName = "boxWrapped"
+  , repMapDomain = wrappedPatternKind
+  , repMapCodomain = boxedPatternKind
+  , repMapForward = \_ p -> Pattern "boxed" [p]
+  , repMapInverse = \_ p ->
       case p of
         Pattern "boxed" [child] -> child
         _ -> p
-  , roundTrip = \q p -> (inverse boxWrappedMap q . forward boxWrappedMap q) p == p
+  , repMapRoundTrip =
+      \q p -> (repMapInverse boxWrappedMap q . repMapForward boxWrappedMap q) p == p
   }
 
 mismatchedBoxMap :: RepresentationMap String
 mismatchedBoxMap = RepresentationMap
-  { name = "mismatchedBox"
-  , domain = aliasedWrappedPatternKind
-  , codomain = boxedPatternKind
-  , forward = \_ p -> Pattern "boxed" [p]
-  , inverse = \_ p ->
+  { repMapName = "mismatchedBox"
+  , repMapDomain = aliasedWrappedPatternKind
+  , repMapCodomain = boxedPatternKind
+  , repMapForward = \_ p -> Pattern "boxed" [p]
+  , repMapInverse = \_ p ->
       case p of
         Pattern "boxed" [child] -> child
         _ -> p
-  , roundTrip = \q p -> (inverse mismatchedBoxMap q . forward mismatchedBoxMap q) p == p
+  , repMapRoundTrip =
+      \q p -> (repMapInverse mismatchedBoxMap q . repMapForward mismatchedBoxMap q) p == p
   }
 
 subjectWith :: String -> [String] -> [(String, Value)] -> Subject
@@ -170,11 +173,9 @@ validDiagnosticPattern pat =
   case pat of
     Pattern locationSubject [diagnosticPat] ->
       hasLabel "Location" locationSubject
-        && case diagnosticPat of
-          Pattern diagnosticSubject remediationPats ->
-            hasLabel "Diagnostic" diagnosticSubject
-              && all isAtomicRemediation remediationPats
-          _ -> False
+        && let Pattern diagnosticSubject remediationPats = diagnosticPat
+           in hasLabel "Diagnostic" diagnosticSubject
+                && all isAtomicRemediation remediationPats
     _ -> False
   where
     isAtomicRemediation (Pattern remediationSubject remediationElements) =
@@ -260,18 +261,6 @@ canonicalDiagnosticGraph =
 subjectSymbolText :: Subject -> String
 subjectSymbolText = (\(Symbol s) -> s) . Subj.identity
 
-graphNodeFromSubject :: Int -> Subject -> Pattern Subject
-graphNodeFromSubject depth subj =
-  Pattern
-    subj
-      { properties =
-          Map.insert "_depth" (VInteger (fromIntegral depth))
-            (Map.insert "_arity" (VInteger (fromIntegral arity)) (properties subj))
-      }
-    []
-  where
-    arity = 0
-
 graphNodeFromPattern :: Int -> Pattern Subject -> Pattern Subject
 graphNodeFromPattern depth pat =
   Pattern updatedSubject []
@@ -351,15 +340,16 @@ diagnosticInverse _ graph =
 
 diagnosticMap :: RepresentationMap Subject
 diagnosticMap = RepresentationMap
-  { name = "diagnosticMap"
-  , domain = diagnosticPatternKind
-  , codomain = diagnosticGraphKind
+  { repMapName = "diagnosticMap"
+  , repMapDomain = diagnosticPatternKind
+  , repMapCodomain = diagnosticGraphKind
     -- The current prototype documents its encoding choices here rather than
     -- storing prose on the map value itself: `_arity` preserves direct element
     -- count and `_depth` preserves nesting depth in graph-form nodes.
-  , forward = diagnosticForward
-  , inverse = diagnosticInverse
-  , roundTrip = \q p -> (inverse diagnosticMap q . forward diagnosticMap q) p == p
+  , repMapForward = diagnosticForward
+  , repMapInverse = diagnosticInverse
+  , repMapRoundTrip =
+      \q p -> (repMapInverse diagnosticMap q . repMapForward diagnosticMap q) p == p
   }
 
 genDiagnosticPattern :: QC.Gen (Pattern Subject)
@@ -379,12 +369,12 @@ genDiagnosticPattern = do
 
 identityLikeMap :: RepresentationMap Subject
 identityLikeMap = RepresentationMap
-  { name = "diagnosticGraphIdentity"
-  , domain = diagnosticGraphKind
-  , codomain = diagnosticGraphKind
-  , forward = \_ p -> p
-  , inverse = \_ p -> p
-  , roundTrip = \_ _ -> True
+  { repMapName = "diagnosticGraphIdentity"
+  , repMapDomain = diagnosticGraphKind
+  , repMapCodomain = diagnosticGraphKind
+  , repMapForward = \_ p -> p
+  , repMapInverse = \_ p -> p
+  , repMapRoundTrip = \_ _ -> True
   }
 
 spec :: Spec
@@ -436,27 +426,33 @@ spec =
           checkKind leafPatternKind (trivialScope example) example `shouldBe` True
           case compose wrapLeafMap boxWrappedMap of
             Left err -> expectationFailure err
-            Right composedMap -> name composedMap `shouldBe` "wrapLeaf >>> boxWrapped"
+            Right composedMap -> repMapName composedMap `shouldBe` "wrapLeaf >>> boxWrapped"
 
-        it "forward produces a pattern accepted by the codomain kind" $ do
-          let domainPattern = kindExample (domain wrapLeafMap)
+        it "repMapForward produces a pattern accepted by the codomain kind" $ do
+          let domainPattern = kindExample (repMapDomain wrapLeafMap)
               scope = trivialScope domainPattern
 
-          checkKind (codomain wrapLeafMap) scope (forward wrapLeafMap scope domainPattern)
+          checkKind
+            (repMapCodomain wrapLeafMap)
+            scope
+            (repMapForward wrapLeafMap scope domainPattern)
             `shouldBe` True
 
-        it "inverse produces a pattern accepted by the domain kind" $ do
-          let codomainPattern = kindExample (codomain wrapLeafMap)
+        it "repMapInverse produces a pattern accepted by the domain kind" $ do
+          let codomainPattern = kindExample (repMapCodomain wrapLeafMap)
               scope = trivialScope codomainPattern
 
-          checkKind (domain wrapLeafMap) scope (inverse wrapLeafMap scope codomainPattern)
+          checkKind
+            (repMapDomain wrapLeafMap)
+            scope
+            (repMapInverse wrapLeafMap scope codomainPattern)
             `shouldBe` True
 
       describe "compose" $ do
         it "returns a composed map with the expected joined name" $ do
           case compose wrapLeafMap boxWrappedMap of
             Left err -> expectationFailure err
-            Right composedMap -> name composedMap `shouldBe` "wrapLeaf >>> boxWrapped"
+            Right composedMap -> repMapName composedMap `shouldBe` "wrapLeaf >>> boxWrapped"
 
         it "returns Left with both kind names when map kinds are incompatible" $ do
           case compose wrapLeafMap mismatchedBoxMap of
@@ -465,7 +461,7 @@ spec =
               err `shouldContain` "AliasedWrapped"
             Right _ -> expectationFailure "Expected incompatible kinds to fail composition"
 
-        it "applies forward then inverse in the documented composition order" $ do
+        it "applies repMapForward then repMapInverse in the documented composition order" $ do
           case compose wrapLeafMap boxWrappedMap of
             Left err -> expectationFailure err
             Right composedMap -> do
@@ -474,39 +470,45 @@ spec =
                   leafScope = trivialScope leafPattern
                   boxedScope = trivialScope boxedPattern
 
-              forward composedMap leafScope leafPattern
-                `shouldBe` forward boxWrappedMap leafScope (forward wrapLeafMap leafScope leafPattern)
+              repMapForward composedMap leafScope leafPattern
+                `shouldBe` repMapForward boxWrappedMap leafScope (repMapForward wrapLeafMap leafScope leafPattern)
 
-              inverse composedMap boxedScope boxedPattern
-                `shouldBe` inverse wrapLeafMap boxedScope (inverse boxWrappedMap boxedScope boxedPattern)
+              repMapInverse composedMap boxedScope boxedPattern
+                `shouldBe` repMapInverse wrapLeafMap boxedScope (repMapInverse boxWrappedMap boxedScope boxedPattern)
 
       describe "diagnosticMap" $ do
-        it "forward maps the canonical diagnostic pattern into the graph kind" $ do
+        it "repMapForward maps the canonical diagnostic pattern into the graph kind" $ do
           let scope = trivialScope canonicalDiagnosticPattern
 
-          checkKind diagnosticGraphKind scope (forward diagnosticMap scope canonicalDiagnosticPattern)
+          checkKind
+            diagnosticGraphKind
+            scope
+            (repMapForward diagnosticMap scope canonicalDiagnosticPattern)
             `shouldBe` True
 
-        it "inverse maps the canonical diagnostic graph into the pattern kind" $ do
+        it "repMapInverse maps the canonical diagnostic graph into the pattern kind" $ do
           let scope = topLevelGraphScope canonicalDiagnosticGraph
 
-          checkKind diagnosticPatternKind scope (inverse diagnosticMap scope canonicalDiagnosticGraph)
+          checkKind
+            diagnosticPatternKind
+            scope
+            (repMapInverse diagnosticMap scope canonicalDiagnosticGraph)
             `shouldBe` True
 
         it "round-trips the canonical diagnostic example" $ do
           let scope = trivialScope canonicalDiagnosticPattern
 
-          (inverse diagnosticMap scope . forward diagnosticMap scope) canonicalDiagnosticPattern
+          (repMapInverse diagnosticMap scope . repMapForward diagnosticMap scope) canonicalDiagnosticPattern
             `shouldBe` canonicalDiagnosticPattern
 
         it "preserves generated diagnostic patterns under round-trip" $
           property $
             QC.forAll genDiagnosticPattern $ \pat ->
-              roundTrip diagnosticMap (trivialScope pat) pat
+              repMapRoundTrip diagnosticMap (trivialScope pat) pat
 
         it "composes with an identity-like graph map and preserves canonical round-trip" $ do
           case compose diagnosticMap identityLikeMap of
             Left err -> expectationFailure err
             Right composedMap ->
-              roundTrip composedMap (trivialScope canonicalDiagnosticPattern) canonicalDiagnosticPattern
+              repMapRoundTrip composedMap (trivialScope canonicalDiagnosticPattern) canonicalDiagnosticPattern
                 `shouldBe` True

--- a/libs/pattern/tests/Spec/Pattern/RepresentationMapSpec.hs
+++ b/libs/pattern/tests/Spec/Pattern/RepresentationMapSpec.hs
@@ -1,0 +1,512 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+module Spec.Pattern.RepresentationMapSpec where
+
+import Data.List (find)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import Pattern (PatternKind(..), RepresentationMap(..), checkKind, compose)
+import Pattern.Core (Pattern(..), ScopeDict(..), ScopeQuery(..), TrivialScope, paraWithScope, trivialScope)
+import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldContain)
+import Subject.Core (Subject(..), Symbol(..))
+import qualified Subject.Core as Subj
+import Subject.Value (Value(..))
+import Test.QuickCheck (Property, property)
+import qualified Test.QuickCheck as QC
+
+newtype VisibleScope v = VisibleScope [Pattern v]
+
+instance ScopeQuery VisibleScope v where
+  type ScopeId VisibleScope v = Int
+
+  containers _ _ = []
+  siblings _ _ = []
+  byIdentity (VisibleScope ps) i
+    | i < 0 = Nothing
+    | otherwise = case drop i ps of
+        p:_ -> Just p
+        [] -> Nothing
+  allElements (VisibleScope ps) = ps
+
+leafPatternKind :: PatternKind String
+leafPatternKind = PatternKind
+  { kindName = "Leaf"
+  , kindPred = \_ p -> value p == "leaf" && null (elements p)
+  , kindExample = Pattern "leaf" []
+  }
+
+branchPatternKind :: PatternKind String
+branchPatternKind = PatternKind
+  { kindName = "BranchWithLeaf"
+  , kindPred = \_ p ->
+      value p == "branch"
+        && case elements p of
+          [Pattern childValue childElements] ->
+            childValue == "leaf" && null childElements
+          _ -> False
+  , kindExample = Pattern "branch" [Pattern "leaf" []]
+  }
+
+visiblePatternKind :: PatternKind String
+visiblePatternKind = PatternKind
+  { kindName = "VisibleLeaf"
+  , kindPred = \q p -> value p == "target" && p `elem` allElements q
+  , kindExample = Pattern "target" []
+  }
+
+wrappedPatternKind :: PatternKind String
+wrappedPatternKind = PatternKind
+  { kindName = "WrappedLeaf"
+  , kindPred = \_ p ->
+      case p of
+        Pattern "wrapped" [child] -> checkKind leafPatternKind (trivialScope child) child
+        _ -> False
+  , kindExample = Pattern "wrapped" [kindExample leafPatternKind]
+  }
+
+boxedPatternKind :: PatternKind String
+boxedPatternKind = PatternKind
+  { kindName = "BoxedLeaf"
+  , kindPred = \_ p ->
+      case p of
+        Pattern "boxed" [child] -> checkKind wrappedPatternKind (trivialScope child) child
+        _ -> False
+  , kindExample = Pattern "boxed" [kindExample wrappedPatternKind]
+  }
+
+aliasedWrappedPatternKind :: PatternKind String
+aliasedWrappedPatternKind = PatternKind
+  { kindName = "AliasedWrapped"
+  , kindPred = kindPred wrappedPatternKind
+  , kindExample = kindExample wrappedPatternKind
+  }
+
+wrapLeafMap :: RepresentationMap String
+wrapLeafMap = RepresentationMap
+  { name = "wrapLeaf"
+  , domain = leafPatternKind
+  , codomain = wrappedPatternKind
+  , forward = \_ p -> Pattern "wrapped" [p]
+  , inverse = \_ p ->
+      case p of
+        Pattern "wrapped" [child] -> child
+        _ -> p
+  , roundTrip = \q p -> (inverse wrapLeafMap q . forward wrapLeafMap q) p == p
+  }
+
+boxWrappedMap :: RepresentationMap String
+boxWrappedMap = RepresentationMap
+  { name = "boxWrapped"
+  , domain = wrappedPatternKind
+  , codomain = boxedPatternKind
+  , forward = \_ p -> Pattern "boxed" [p]
+  , inverse = \_ p ->
+      case p of
+        Pattern "boxed" [child] -> child
+        _ -> p
+  , roundTrip = \q p -> (inverse boxWrappedMap q . forward boxWrappedMap q) p == p
+  }
+
+mismatchedBoxMap :: RepresentationMap String
+mismatchedBoxMap = RepresentationMap
+  { name = "mismatchedBox"
+  , domain = aliasedWrappedPatternKind
+  , codomain = boxedPatternKind
+  , forward = \_ p -> Pattern "boxed" [p]
+  , inverse = \_ p ->
+      case p of
+        Pattern "boxed" [child] -> child
+        _ -> p
+  , roundTrip = \q p -> (inverse mismatchedBoxMap q . forward mismatchedBoxMap q) p == p
+  }
+
+subjectWith :: String -> [String] -> [(String, Value)] -> Subject
+subjectWith sym lbls props =
+  Subject (Symbol sym) (Set.fromList lbls) (Map.fromList props)
+
+nodePattern :: String -> String -> [(String, Value)] -> Pattern Subject
+nodePattern sym lbl props = Pattern (subjectWith sym [lbl] props) []
+
+relationshipPattern :: String -> String -> Pattern Subject -> Pattern Subject -> Pattern Subject
+relationshipPattern sym lbl src tgt =
+  Pattern (subjectWith sym [lbl] []) [src, tgt]
+
+graphRoot :: String -> [Pattern Subject] -> Pattern Subject
+graphRoot sym es = Pattern (subjectWith sym ["DiagnosticGraph"] []) es
+
+hasLabel :: String -> Subject -> Bool
+hasLabel lbl subj = lbl `Set.member` Subj.labels subj
+
+patternHasLabel :: String -> Pattern Subject -> Bool
+patternHasLabel lbl = hasLabel lbl . value
+
+integerProperty :: String -> Subject -> Maybe Integer
+integerProperty key subj =
+  case Map.lookup key (properties subj) of
+    Just (VInteger n) -> Just n
+    _ -> Nothing
+
+stripDiagnosticMetadata :: Subject -> Subject
+stripDiagnosticMetadata subj =
+  subj { properties = Map.delete "_depth" (Map.delete "_arity" (properties subj)) }
+
+topLevelGraphScope :: Pattern Subject -> ScopeDict Symbol Subject
+topLevelGraphScope graph = ScopeDict
+  { dictContainers = \pat -> filter (\container -> pat `elem` elements container) topLevel
+  , dictSiblings = \pat ->
+      concatMap
+        (\container -> filter (/= pat) (elements container))
+        (filter (\container -> pat `elem` elements container) topLevel)
+  , dictByIdentity = \sym -> find ((== sym) . Subj.identity . value) topLevel
+  , dictAllElements = topLevel
+  }
+  where
+    topLevel = elements graph
+
+validDiagnosticPattern :: Pattern Subject -> Bool
+validDiagnosticPattern pat =
+  case pat of
+    Pattern locationSubject [diagnosticPat] ->
+      hasLabel "Location" locationSubject
+        && case diagnosticPat of
+          Pattern diagnosticSubject remediationPats ->
+            hasLabel "Diagnostic" diagnosticSubject
+              && all isAtomicRemediation remediationPats
+          _ -> False
+    _ -> False
+  where
+    isAtomicRemediation (Pattern remediationSubject remediationElements) =
+      hasLabel "Remediation" remediationSubject && null remediationElements
+
+validGraphElement :: Pattern Subject -> Bool
+validGraphElement pat
+  | patternHasLabel "Location" pat = atomicEntity pat
+  | patternHasLabel "Diagnostic" pat = atomicEntity pat
+  | patternHasLabel "Remediation" pat = atomicEntity pat
+  | patternHasLabel "AT" pat = binaryRelationship "Location" "Diagnostic" pat
+  | patternHasLabel "HAS_REMEDIATION" pat = binaryRelationship "Diagnostic" "Remediation" pat
+  | otherwise = False
+  where
+    atomicEntity (Pattern subj childPats) =
+      null childPats
+        && integerProperty "_arity" subj /= Nothing
+        && integerProperty "_depth" subj /= Nothing
+    binaryRelationship sourceLabel targetLabel (Pattern subj [src, tgt]) =
+      null (properties subj)
+        && patternHasLabel sourceLabel src
+        && patternHasLabel targetLabel tgt
+    binaryRelationship _ _ _ = False
+
+connectedBy :: String -> Pattern Subject -> Pattern Subject -> Pattern Subject -> Bool
+connectedBy relLabel src tgt relPat =
+  patternHasLabel relLabel relPat
+    && case elements relPat of
+      [relSrc, relTgt] -> relSrc == src && relTgt == tgt
+      _ -> False
+
+diagnosticPatternKind :: PatternKind Subject
+diagnosticPatternKind = PatternKind
+  { kindName = "DiagnosticPattern"
+  , kindPred = \_ -> validDiagnosticPattern
+  , kindExample = canonicalDiagnosticPattern
+  }
+
+diagnosticGraphKind :: PatternKind Subject
+diagnosticGraphKind = PatternKind
+  { kindName = "DiagnosticGraph"
+  , kindPred = \_ graph ->
+      hasLabel "DiagnosticGraph" (value graph)
+        && let scope = topLevelGraphScope graph
+               graphElements = allElements scope
+               locations = filter (patternHasLabel "Location") graphElements
+               diagnostics = filter (patternHasLabel "Diagnostic") graphElements
+               remediations = filter (patternHasLabel "Remediation") graphElements
+               atRels = filter (patternHasLabel "AT") graphElements
+               remediationRels = filter (patternHasLabel "HAS_REMEDIATION") graphElements
+           in all validGraphElement graphElements
+                && case (locations, diagnostics, atRels) of
+                  ([loc], [diag], [atRel]) ->
+                    connectedBy "AT" loc diag atRel
+                      && all
+                        (\remediation ->
+                          any (connectedBy "HAS_REMEDIATION" diag remediation) remediationRels
+                        )
+                        remediations
+                      && length remediationRels == length remediations
+                  _ -> False
+  , kindExample = canonicalDiagnosticGraph
+  }
+
+canonicalDiagnosticPattern :: Pattern Subject
+canonicalDiagnosticPattern =
+  Pattern (subjectWith "location-0" ["Location"] [])
+    [ Pattern (subjectWith "diagnostic-0" ["Diagnostic"] [])
+        [ Pattern (subjectWith "remediation-0" ["Remediation"] []) []
+        ]
+    ]
+
+canonicalDiagnosticGraph :: Pattern Subject
+canonicalDiagnosticGraph =
+  let locationNode = nodePattern "location-0" "Location" [("_arity", VInteger 1), ("_depth", VInteger 0)]
+      diagnosticNode = nodePattern "diagnostic-0" "Diagnostic" [("_arity", VInteger 1), ("_depth", VInteger 1)]
+      remediationNode = nodePattern "remediation-0" "Remediation" [("_arity", VInteger 0), ("_depth", VInteger 2)]
+      atRel = relationshipPattern "at-location-diagnostic" "AT" locationNode diagnosticNode
+      remediationRel =
+        relationshipPattern "has-remediation-0" "HAS_REMEDIATION" diagnosticNode remediationNode
+  in graphRoot "diagnostic-graph-0" [locationNode, diagnosticNode, remediationNode, atRel, remediationRel]
+
+subjectSymbolText :: Subject -> String
+subjectSymbolText = (\(Symbol s) -> s) . Subj.identity
+
+graphNodeFromSubject :: Int -> Subject -> Pattern Subject
+graphNodeFromSubject depth subj =
+  Pattern
+    subj
+      { properties =
+          Map.insert "_depth" (VInteger (fromIntegral depth))
+            (Map.insert "_arity" (VInteger (fromIntegral arity)) (properties subj))
+      }
+    []
+  where
+    arity = 0
+
+graphNodeFromPattern :: Int -> Pattern Subject -> Pattern Subject
+graphNodeFromPattern depth pat =
+  Pattern updatedSubject []
+  where
+    updatedSubject =
+      (value pat)
+        { properties =
+            Map.insert "_depth" (VInteger (fromIntegral depth))
+              (Map.insert "_arity" (VInteger (fromIntegral (length (elements pat)))) (properties (value pat)))
+        }
+
+relationshipId :: String -> Pattern Subject -> Pattern Subject -> String
+relationshipId prefix src tgt =
+  prefix <> "-" <> subjectSymbolText (value src) <> "-" <> subjectSymbolText (value tgt)
+
+diagnosticForward :: ScopeQuery q Subject => q Subject -> Pattern Subject -> Pattern Subject
+diagnosticForward q pat =
+  graphRoot (subjectSymbolText (value pat) <> "-graph") graphElements
+  where
+    (_, graphElements) = paraWithScope q build pat 0
+
+    build :: ScopeQuery q Subject => q Subject -> Pattern Subject -> [Int -> (Pattern Subject, [Pattern Subject])] -> Int -> (Pattern Subject, [Pattern Subject])
+    build _ current childBuilders depth =
+      let currentNode = graphNodeFromPattern depth current
+          childResults = map ($ (depth + 1)) childBuilders
+          childNodes = map fst childResults
+          childElements = concatMap snd childResults
+          rels = concatMap (relationshipFor currentNode) childNodes
+      in (currentNode, [currentNode] ++ childElements ++ rels)
+
+    relationshipFor :: Pattern Subject -> Pattern Subject -> [Pattern Subject]
+    relationshipFor parentNode childNode
+      | patternHasLabel "Location" parentNode && patternHasLabel "Diagnostic" childNode =
+          [relationshipPattern (relationshipId "at" parentNode childNode) "AT" parentNode childNode]
+      | patternHasLabel "Diagnostic" parentNode && patternHasLabel "Remediation" childNode =
+          [relationshipPattern (relationshipId "has-remediation" parentNode childNode) "HAS_REMEDIATION" parentNode childNode]
+      | otherwise = []
+
+diagnosticInverse :: ScopeQuery q Subject => q Subject -> Pattern Subject -> Pattern Subject
+diagnosticInverse _ graph =
+  case find (patternHasLabel "Diagnostic") graphElements of
+    Nothing -> graph
+    Just diagnosticNode ->
+      case findLocation diagnosticNode of
+        Nothing -> graph
+        Just locationNode ->
+          Pattern (stripDiagnosticMetadata (value locationNode))
+            [ Pattern (stripDiagnosticMetadata (value diagnosticNode))
+                (map toRemediationPattern remediationNodes)
+            ]
+      where
+        remediationNodes =
+          filter
+            (\candidate ->
+              patternHasLabel "Remediation" candidate
+                && any (connectedBy "HAS_REMEDIATION" diagnosticNode candidate) (containers scope candidate)
+            )
+            graphElements
+  where
+    scope = topLevelGraphScope graph
+    graphElements = allElements scope
+
+    findLocation diagnosticNode =
+      do
+        atRel <- find (connectedToDiagnostic diagnosticNode) (containers scope diagnosticNode)
+        case elements atRel of
+          [locationNode, _] | patternHasLabel "Location" locationNode -> Just locationNode
+          _ -> Nothing
+
+    connectedToDiagnostic diagnosticNode rel =
+      patternHasLabel "AT" rel
+        && case elements rel of
+          [_, targetNode] -> targetNode == diagnosticNode
+          _ -> False
+
+    toRemediationPattern remNode = Pattern (stripDiagnosticMetadata (value remNode)) []
+
+diagnosticMap :: RepresentationMap Subject
+diagnosticMap = RepresentationMap
+  { name = "diagnosticMap"
+  , domain = diagnosticPatternKind
+  , codomain = diagnosticGraphKind
+    -- The current prototype documents its encoding choices here rather than
+    -- storing prose on the map value itself: `_arity` preserves direct element
+    -- count and `_depth` preserves nesting depth in graph-form nodes.
+  , forward = diagnosticForward
+  , inverse = diagnosticInverse
+  , roundTrip = \q p -> (inverse diagnosticMap q . forward diagnosticMap q) p == p
+  }
+
+genDiagnosticPattern :: QC.Gen (Pattern Subject)
+genDiagnosticPattern = do
+  seed <- QC.chooseInt (1, 100000)
+  remediationCount <- QC.chooseInt (0, 3)
+  let locationId = "location-" <> show seed
+      diagnosticId = "diagnostic-" <> show seed
+      remediationIds = [0 .. remediationCount - 1]
+      remediationPats =
+        [ Pattern (subjectWith ("remediation-" <> show seed <> "-" <> show idx) ["Remediation"] []) []
+        | idx <- remediationIds
+        ]
+  pure $
+    Pattern (subjectWith locationId ["Location"] [])
+      [Pattern (subjectWith diagnosticId ["Diagnostic"] []) remediationPats]
+
+identityLikeMap :: RepresentationMap Subject
+identityLikeMap = RepresentationMap
+  { name = "diagnosticGraphIdentity"
+  , domain = diagnosticGraphKind
+  , codomain = diagnosticGraphKind
+  , forward = \_ p -> p
+  , inverse = \_ p -> p
+  , roundTrip = \_ _ -> True
+  }
+
+spec :: Spec
+spec =
+  describe "Pattern.RepresentationMap scaffolding" $
+    do
+      describe "PatternKind" $ do
+        it "canonical example satisfies its own kind" $ do
+          let results =
+                [ kindPred leafPatternKind
+                    (trivialScope (kindExample leafPatternKind))
+                    (kindExample leafPatternKind)
+                , kindPred branchPatternKind
+                    (trivialScope (kindExample branchPatternKind))
+                    (kindExample branchPatternKind)
+                , kindPred visiblePatternKind
+                    (trivialScope (kindExample visiblePatternKind))
+                    (kindExample visiblePatternKind)
+                ]
+
+          results `shouldBe` [True, True, True]
+
+        it "returns False for a pattern outside the kind's structural constraint" $ do
+          let nonMatching = Pattern "branch" [Pattern "twig" []]
+
+          checkKind branchPatternKind (trivialScope nonMatching) nonMatching `shouldBe` False
+
+        it "can use allElements to recognize patterns visible only through scope" $ do
+          let hidden = Pattern "target" []
+              root = Pattern "root" [Pattern "other" []]
+              visibleScope = VisibleScope [root, hidden]
+
+          checkKind visiblePatternKind visibleScope hidden `shouldBe` True
+          checkKind visiblePatternKind (trivialScope root) hidden `shouldBe` False
+
+        it "returns the same result for structural predicates regardless of scope" $ do
+          let candidate = kindExample leafPatternKind
+              narrowScope :: TrivialScope String
+              narrowScope = trivialScope candidate
+              wideScope = VisibleScope [Pattern "noise" [], candidate, kindExample branchPatternKind]
+
+          kindPred leafPatternKind narrowScope candidate
+            `shouldBe` kindPred leafPatternKind wideScope candidate
+
+      describe "RepresentationMap" $ do
+        it "re-exports key APIs from Pattern" $ do
+          let example = kindExample leafPatternKind
+
+          checkKind leafPatternKind (trivialScope example) example `shouldBe` True
+          case compose wrapLeafMap boxWrappedMap of
+            Left err -> expectationFailure err
+            Right composedMap -> name composedMap `shouldBe` "wrapLeaf >>> boxWrapped"
+
+        it "forward produces a pattern accepted by the codomain kind" $ do
+          let domainPattern = kindExample (domain wrapLeafMap)
+              scope = trivialScope domainPattern
+
+          checkKind (codomain wrapLeafMap) scope (forward wrapLeafMap scope domainPattern)
+            `shouldBe` True
+
+        it "inverse produces a pattern accepted by the domain kind" $ do
+          let codomainPattern = kindExample (codomain wrapLeafMap)
+              scope = trivialScope codomainPattern
+
+          checkKind (domain wrapLeafMap) scope (inverse wrapLeafMap scope codomainPattern)
+            `shouldBe` True
+
+      describe "compose" $ do
+        it "returns a composed map with the expected joined name" $ do
+          case compose wrapLeafMap boxWrappedMap of
+            Left err -> expectationFailure err
+            Right composedMap -> name composedMap `shouldBe` "wrapLeaf >>> boxWrapped"
+
+        it "returns Left with both kind names when map kinds are incompatible" $ do
+          case compose wrapLeafMap mismatchedBoxMap of
+            Left err -> do
+              err `shouldContain` "WrappedLeaf"
+              err `shouldContain` "AliasedWrapped"
+            Right _ -> expectationFailure "Expected incompatible kinds to fail composition"
+
+        it "applies forward then inverse in the documented composition order" $ do
+          case compose wrapLeafMap boxWrappedMap of
+            Left err -> expectationFailure err
+            Right composedMap -> do
+              let leafPattern = kindExample leafPatternKind
+                  boxedPattern = kindExample boxedPatternKind
+                  leafScope = trivialScope leafPattern
+                  boxedScope = trivialScope boxedPattern
+
+              forward composedMap leafScope leafPattern
+                `shouldBe` forward boxWrappedMap leafScope (forward wrapLeafMap leafScope leafPattern)
+
+              inverse composedMap boxedScope boxedPattern
+                `shouldBe` inverse wrapLeafMap boxedScope (inverse boxWrappedMap boxedScope boxedPattern)
+
+      describe "diagnosticMap" $ do
+        it "forward maps the canonical diagnostic pattern into the graph kind" $ do
+          let scope = trivialScope canonicalDiagnosticPattern
+
+          checkKind diagnosticGraphKind scope (forward diagnosticMap scope canonicalDiagnosticPattern)
+            `shouldBe` True
+
+        it "inverse maps the canonical diagnostic graph into the pattern kind" $ do
+          let scope = topLevelGraphScope canonicalDiagnosticGraph
+
+          checkKind diagnosticPatternKind scope (inverse diagnosticMap scope canonicalDiagnosticGraph)
+            `shouldBe` True
+
+        it "round-trips the canonical diagnostic example" $ do
+          let scope = trivialScope canonicalDiagnosticPattern
+
+          (inverse diagnosticMap scope . forward diagnosticMap scope) canonicalDiagnosticPattern
+            `shouldBe` canonicalDiagnosticPattern
+
+        it "preserves generated diagnostic patterns under round-trip" $
+          property $
+            QC.forAll genDiagnosticPattern $ \pat ->
+              roundTrip diagnosticMap (trivialScope pat) pat
+
+        it "composes with an identity-like graph map and preserves canonical round-trip" $ do
+          case compose diagnosticMap identityLikeMap of
+            Left err -> expectationFailure err
+            Right composedMap ->
+              roundTrip composedMap (trivialScope canonicalDiagnosticPattern) canonicalDiagnosticPattern
+                `shouldBe` True

--- a/libs/pattern/tests/Test.hs
+++ b/libs/pattern/tests/Test.hs
@@ -11,6 +11,7 @@ import qualified Spec.Pattern.Graph.TransformSpec as TransformSpec
 import qualified Spec.Pattern.PatternGraphProperties as PatternGraphProperties
 import qualified Spec.Pattern.PatternGraphSpec as PatternGraphSpec
 import qualified Spec.Pattern.Properties as Properties
+import qualified Spec.Pattern.RepresentationMapSpec as RepresentationMapSpec
 import qualified Spec.Pattern.ReconcileSpec as ReconcileSpec
 import qualified Spec.Pattern.ReconcileProperties as ReconcileProperties
 
@@ -29,6 +30,7 @@ testSpec = do
     PatternGraphSpec.spec
     PatternGraphProperties.spec
     Properties.spec
+    RepresentationMapSpec.spec
     ReconcileSpec.spec
     ReconcileProperties.spec
 

--- a/proposals/representation-map-proposal.md
+++ b/proposals/representation-map-proposal.md
@@ -1,0 +1,619 @@
+# Proposal: RepresentationMap for pattern-hs
+
+**Status:** Design — forward-looking, not yet a specification  
+**Date:** 2026-03-17  
+**Depends on:** GraphTransform proposal, pattern-equivalence proposal  
+**Followed by:** Rust port (`pattern-rs`), pato surface (`pato canonicalize`)  
+**Location:** `proposals/representation-map.md` within the `pattern-hs` workspace
+
+---
+
+## Summary
+
+Introduce `RepresentationMap` as a named, invertible, composable isomorphism between
+two *kinds of shape* — named, recognizable shapes of `Pattern<V>` — where both kinds
+are subtypes of `Pattern<V>` and the isomorphism is witnessed by a machine-checkable
+round-trip property.
+
+This proposal also captures a foundational clarification about scope and containment
+that applies across both pattern-level and graph-level operations, and identifies
+refactoring implied for the `GraphQuery` and `GraphTransform` interfaces.
+
+The intended implementation sequence is: Haskell prototype → confidence in the
+abstraction → Rust port (`pattern-rs`) → CLI surface (`pato canonicalize`).
+
+---
+
+## Foundational principle: scope is defined by an element
+
+**Scope is not a query interface. Scope is an element. An element defines the scope
+of everything it contains.**
+
+This is already true in `Pattern<V>`: a pattern element is a scope for its direct
+elements and for everything transitively nested within it. The gram document root is a
+scope for all top-level patterns. A sub-pattern is a scope for its own elements.
+Containment is the core structural relationship in `Pattern<V>`, and scope is just
+containment viewed from the other direction.
+
+Query interfaces are not *the scope*. They are *efficient accessors into a scope
+defined by a containing element*. The element comes first; the query interface is
+derived from it. The caller decides what the scope container is and constructs the
+appropriate query from it.
+
+This unifies what were previously treated as separate concerns:
+
+- `para` on `Pattern<V>` gives each node access to its *immediate* context — the
+  pattern itself and the bottom-up results of its direct elements. Scope defined by
+  the current element looking inward.
+- `paraGraph` on `GraphView` gives each element access to *broader* context — the
+  scope defined by the enclosing `GraphView` element, looking outward: who contains
+  me, who are my neighbors, what relationships am I part of?
+- The difference is not "pattern vs graph" — it is **the scope boundary**: immediate
+  children vs the whole containing element.
+
+Both are instances of the same general operation: a fold where the folding function
+has access to child results *and* to the query interface for the broader containing
+scope.
+
+---
+
+## Scope as a typeclass
+
+The scope query interface is a typeclass. Different kinds of scope provide different
+operations, with richer kinds extending simpler ones:
+
+```haskell
+class ScopeQuery q v where
+  containers  :: q v -> Pattern v -> [Pattern v]
+    -- ^ patterns that directly contain this element within the scope
+  siblings    :: q v -> Pattern v -> [Pattern v]
+    -- ^ co-elements of the same immediate parent within the scope
+  byIdentity  :: q v -> Id v -> Maybe (Pattern v)
+    -- ^ look up any element in scope by identity
+  allElements :: q v -> [Pattern v]
+    -- ^ enumerate all elements within the scope
+```
+
+`GraphQuery` is a `ScopeQuery` that operates on patterns classified as graph-shaped —
+the graph classification kinds (`GNode`, `GRelationship`, `GWalk`, `GAnnotation`) are
+the kinds of shape that make graph-specific operations meaningful. `querySource` is
+only valid on a `GRelationship`-kinded pattern; `queryIncidentRels` is only valid on a
+`GNode`-kinded pattern. These are not operations bolted onto scope from outside — they
+are scope operations that are valid *because* the patterns being queried satisfy
+specific kind constraints.
+
+```haskell
+-- GraphQuery is a ScopeQuery for graph-classified patterns
+instance ScopeQuery GraphQuery v where
+  containers  q = queryContainers q
+  siblings    q p = concatMap elements (queryContainers q p)
+  byIdentity  q = queryNodeById q
+  allElements q = queryNodes q ++ queryRelationships q
+
+-- Additional operations valid only within graph kinds
+class ScopeQuery q v => GraphScope q v where
+  source    :: q v -> Pattern v -> Maybe (Pattern v)
+  target    :: q v -> Pattern v -> Maybe (Pattern v)
+  incidents :: q v -> Pattern v -> [Pattern v]
+  degree    :: q v -> Pattern v -> Int
+  nodes     :: q v -> [Pattern v]
+  rels      :: q v -> [Pattern v]
+
+instance GraphScope GraphQuery v where
+  source    = querySource
+  target    = queryTarget
+  incidents = queryIncidentRels
+  degree    = queryDegree
+  nodes     = queryNodes
+  rels      = queryRelationships
+```
+
+A trivial scope instance handles the immediate-children-only case:
+
+```haskell
+newtype TrivialScope v = TrivialScope (Pattern v)
+
+instance ScopeQuery TrivialScope v where
+  containers  _ _ = []
+  siblings    _ _ = []
+  byIdentity  (TrivialScope p) i = findInSubtree i p
+  allElements (TrivialScope p)   = subtreeElements p
+```
+
+The caller constructs whichever scope is appropriate for their container:
+
+```haskell
+trivialScope :: Pattern v -> TrivialScope v
+trivialScope = TrivialScope
+
+-- Any other scope the caller wishes to define —
+-- e.g. a GraphView, a gram document, a project corpus —
+-- is an instance of ScopeQuery constructed the same way.
+```
+
+---
+
+## Interface convention: typeclass + dictionary + instances
+
+This proposal introduces `ScopeQuery` and `GraphScope` as typeclasses. This is a
+deliberate departure from the existing pattern-hs convention of records-of-functions
+(`GraphQuery`, `GraphClassifier`), and the reasoning is worth stating formally because
+it establishes the convention for all future interfaces in pattern-hs.
+
+### Why not records-of-functions for the interface?
+
+The original motivation for records-of-functions was portability: records look
+structurally similar to Rust structs, which was thought to ease porting. This conflates
+*implementation similarity* with *semantic portability*. A Rust developer porting
+`ScopeQuery` does not need Haskell to look like Rust — they need the design document
+to clearly state the correspondence. Portability is a property of the *design*,
+documented in the porting guide, not a property of the syntax.
+
+### The resolved approach
+
+Each language uses its idiomatic equivalent for interface definition:
+
+- **Haskell** — typeclasses (`ScopeQuery`, `GraphScope`). GHC can inline through
+  typeclass dispatch and specialise instances, which matters for `paraWithScope` as a
+  tight inner loop.
+- **Rust** — traits (`ScopeQuery<V>`, `GraphScope<V>`). Trait objects (`&dyn
+  ScopeQuery<V>`) at FFI and dynamic-dispatch boundaries.
+- **Python / TypeScript via WASM** — protocols or interfaces derived from the Rust
+  trait objects at the WASM boundary.
+
+The porting guide states the correspondence explicitly. Visual similarity between
+language constructs is not the goal; semantic fidelity is.
+
+### Typeclasses and records-of-functions compose
+
+Within Haskell, typeclasses and records-of-functions are not alternatives — they
+compose. A `*Dict` record is provided alongside each typeclass as the first-class value
+form, useful when a dictionary needs to be stored in a data structure, passed to a
+non-polymorphic higher-order function, or constructed dynamically at runtime. The
+`*Dict` record is itself a typeclass instance, and any typeclass instance can be
+reified into a `*Dict` via a `toDict` function:
+
+```haskell
+data ScopeDict v = ScopeDict
+  { dictContainers  :: Pattern v -> [Pattern v]
+  , dictSiblings    :: Pattern v -> [Pattern v]
+  , dictByIdentity  :: Id v -> Maybe (Pattern v)
+  , dictAllElements :: [Pattern v]
+  }
+
+instance ScopeQuery ScopeDict v where
+  containers  = dictContainers
+  siblings    = dictSiblings
+  byIdentity  = dictByIdentity
+  allElements = const . dictAllElements
+
+-- Reify any ScopeQuery instance into a first-class dictionary value
+toDict :: ScopeQuery q v => q v -> ScopeDict v
+toDict q = ScopeDict
+  { dictContainers  = containers q
+  , dictSiblings    = siblings q
+  , dictByIdentity  = byIdentity q
+  , dictAllElements = allElements q
+  }
+```
+
+### Existing records are not converted
+
+The existing `GraphQuery` and `GraphClassifier` records are **not** converted to
+typeclasses — that would be a breaking change with limited benefit. Instead, they gain
+typeclass instances (`ScopeQuery GraphQuery`, `GraphScope GraphQuery`), with their
+existing record fields becoming the implementations. All existing code that passes
+`GraphQuery` values around continues to work unchanged. The design evolves forward
+without disruption.
+
+### Going-forward convention
+
+New interfaces in pattern-hs follow this pattern:
+
+1. Define the interface as a typeclass
+2. Provide a `*Dict` record as the first-class value form, with a `toDict` reification
+   function
+3. Give existing records typeclass instances where they satisfy the interface
+4. Document the cross-language correspondence in the porting guide
+
+---
+
+## The unified operation: `paraWithScope`
+
+```haskell
+paraWithScope :: ScopeQuery q v
+              => q v
+              -> (q v -> Pattern v -> [r] -> r)
+              -> Pattern v
+              -> r
+```
+
+`para` and `paraGraph` become derived operations, both instances of the same
+underlying fold at different scope levels:
+
+```haskell
+para :: (Pattern v -> [r] -> r) -> Pattern v -> r
+para f p = paraWithScope (trivialScope p) (\_ pat rs -> f pat rs) p
+
+paraGraph :: (GraphQuery v -> Pattern v -> [r] -> r)
+          -> GraphView extra v -> Map (Id v) r
+paraGraph f view =
+  paraWithScope (viewQuery view) f (viewRoot view)
+```
+
+The full set of scope-aware operations — fold, map, filter — can be defined once
+against `ScopeQuery q v` and reused at every scope level. `paraGraph`,
+`mapWithContext`, and `filterGraph` become derived, not primitive.
+
+---
+
+## Implications for graph interface refactoring
+
+The typeclass formulation makes the refactoring straightforward:
+
+- `ScopeQuery` is a new typeclass in `Pattern.Core`, with `TrivialScope` as its
+  simplest instance
+- `GraphQuery` gains a `ScopeQuery` instance and a `GraphScope` subclass instance —
+  the existing record fields become the implementations
+- `paraWithScope` replaces `para` as the primitive; `para` is redefined in terms of it
+- `paraGraph`, `mapWithContext`, `filterGraph` are redefined against `ScopeQuery q v`
+
+No existing call sites break. The refactoring is additive and exposes a cleaner
+structure without removing anything.
+
+### Concrete changes
+
+| Component | Action | Notes |
+|-----------|--------|-------|
+| `ScopeQuery` typeclass | **New** in `Pattern.Core` | Scope ops for any `Pattern<V>` |
+| `GraphScope` typeclass | **New** in `Pattern.Graph` | Graph-specific ops; subclass of `ScopeQuery` |
+| `TrivialScope` | **New** in `Pattern.Core` | `ScopeQuery` instance for immediate-children scope |
+| `ScopeQuery GraphQuery` instance | **New** in `Pattern.Graph` | Declares `GraphQuery` as a scope |
+| `GraphScope GraphQuery` instance | **New** in `Pattern.Graph` | Graph operations as scope extensions |
+| `paraWithScope` | **New** in `Pattern.Core` | General scope-aware fold; unified primitive |
+| `para` | **Redefine** as `paraWithScope (trivialScope p)` | No API breakage |
+| `paraGraph` | **Redefine** as `paraWithScope (viewQuery view)` | No API breakage |
+| `mapWithContext` | **Redefine** to use `ScopeQuery q v` constraint | Broader applicability |
+| `filterGraph` | **Redefine** where scope-only predicates suffice | `GraphScope` still needed for topology-dependent predicates |
+
+---
+
+## Kinds of shape
+
+A **kind of shape** is a named, recognizable shape of `Pattern<V>` — a description of
+the structural constraints that a pattern must satisfy to be considered an instance of
+that kind. It is a subtype of `Pattern<V>` defined by a predicate, not by the type
+system.
+
+The vocabulary is already present in gram notation: `{ kind: "diagnostics" }` in a
+document header declares the document's kind. `*.schema.gram` files describe kinds.
+`::` labels and `==>` arrows signal schema intent. "Kind of shape" gives this existing
+practice a precise name.
+
+A kind is not an individual pattern — it is the description. A specific diagnostic
+pattern is *of kind* `DiagnosticPattern`; it is not itself a kind.
+
+The graph classification kinds (`GNode`, `GRelationship`, `GWalk`, `GAnnotation`) are
+kinds of shape in exactly this sense — they are the recognizable shapes that
+`GraphClassifier` detects and that `GraphScope` operations are defined over.
+`GraphQuery` is the scope query for patterns of those kinds. This confirms that
+`GraphQuery` is not a separate concept from `ScopeQuery` — it is `ScopeQuery`
+instantiated for graph-classified kinds.
+
+```haskell
+data PatternKind v = PatternKind
+  { kindName    :: Text
+    -- ^ e.g. "DiagnosticPattern", "DiagnosticGraph", "GNode"
+  , kindPred    :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ true iff a pattern is of this kind within a given scope
+  , kindExample :: Pattern v
+    -- ^ canonical example for property-based test generation
+  }
+```
+
+`kindPred` is polymorphic over scope queries: a shape constraint may be purely
+structural (check the pattern itself) or scope-relative (check cross-references within
+the containing scope). Both cases use the same predicate signature.
+
+The long-term path from `PatternKind` to gram-described schemas is direct: a
+`*.schema.gram` file describes a kind, and `pato validate` checks kind membership.
+`PatternKind` is the programmatic representation of what a schema describes.
+
+---
+
+## RepresentationMap
+
+A `RepresentationMap` is an isomorphism between two kinds of shape. It maps every
+pattern of kind `A` to a pattern of kind `B`, and back, with the round-trip property
+as the machine-checkable witness to the isomorphism.
+
+This is `Pattern v <-> Pattern v` in the general case — not specifically
+pattern-to-graph. Graph form is one common codomain, but any two kinds of shape can be
+related by a `RepresentationMap`. Examples:
+
+- Nested diagnostic pattern ↔ flat node-relationship diagnostic graph
+- Positional sequence encoding ↔ labeled property encoding
+- Compact scalar representation ↔ expanded structural representation
+- Hierarchy-as-nesting ↔ hierarchy-as-membership-edges
+
+```haskell
+data RepresentationMap v = RepresentationMap
+  { name        :: Text
+  , domain      :: PatternKind v
+  , codomain    :: PatternKind v
+  , conventions :: [Text]
+    -- ^ named structural decisions that make the round-trip work
+  , forward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , inverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , roundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ witness: (inverse q . forward q) p == p for all p of kind domain
+  }
+```
+
+`forward` and `inverse` are polymorphic over scope queries. A transform that needs
+only general scope operations works at `ScopeQuery q v`. A transform that needs
+graph topology constrains its scope further:
+
+```haskell
+-- A map whose source is graph-shaped needs GraphScope
+graphAwareForward :: (GraphScope q v) => q v -> Pattern v -> Pattern v
+```
+
+The constraint hierarchy in the scope typeclasses mirrors the kind hierarchy in the
+data. A `RepresentationMap` between graph-kinded patterns uses a `GraphScope`-
+constrained transform; one between arbitrary pattern-kinded shapes uses only
+`ScopeQuery`. The type system enforces the correspondence.
+
+### Conventions
+
+Invertibility is not free. When a kind of shape does not carry all the information
+needed to reconstruct the source from the target, the forward transform must encode
+structural metadata into the target. These encoding decisions are **conventions**.
+
+Conventions are part of the map's identity. Two maps with the same `forward` function
+but different encoding decisions produce different codeomain patterns and require
+different inverse functions. An undocumented convention is a convention that will be
+misread.
+
+In the prototype, conventions are named text. Long-term they may be expressed as gram
+annotations on the codomain's schema, making them inspectable without reading source
+code and connecting `RepresentationMap` directly to the `pato validate` infrastructure.
+
+### Relationship to GraphTransform
+
+`RepresentationMap` sits above `GraphTransform` in the abstraction stack. The
+primitive operations from `GraphTransform` (`mapGraph`, `unfoldGraph`, `foldGraph`)
+and `Pattern.Core` (`paraWithScope`, `unfold`, `map`) are how you *build* the
+`forward` and `inverse` functions. `RepresentationMap` is how you *declare* that they
+are each other's inverse, name the kinds they operate between, and record the
+conventions that make the round-trip work.
+
+### Composability
+
+Two `RepresentationMap`s compose when the codomain of the first matches the domain of
+the second:
+
+```haskell
+compose :: RepresentationMap v -> RepresentationMap v -> RepresentationMap v
+compose m1 m2 = RepresentationMap
+  { name        = name m1 <> " >>> " <> name m2
+  , domain      = domain m1
+  , codomain    = codomain m2
+  , conventions = conventions m1 <> conventions m2
+  , forward     = \q p -> forward m2 q (forward m1 q p)
+  , inverse     = \q p -> inverse m1 q (inverse m2 q p)
+  , roundTrip   = \q p -> roundTrip m1 q p && roundTrip m2 q p
+  }
+```
+
+The composed map carries the union of both maps' conventions. The space of kinds of
+shape is navigable: name intermediate forms, chain mappings, track every structural
+decision along the way.
+
+A library of named maps, each with declared kinds and conventions:
+
+```haskell
+diagnosticMap :: RepresentationMap Subject
+  -- domain:      DiagnosticPattern (nested location/diagnostic/remediation)
+  -- codomain:    DiagnosticGraph   (flat nodes + AT/HAS_REMEDIATION edges)
+  -- conventions: ["_arity encodes element count", "_depth encodes nesting depth"]
+
+organizationMap :: RepresentationMap Subject
+  -- domain:      OrgHierarchy (nested department/person structure)
+  -- codomain:    OrgGraph     (nodes + MEMBER_OF edges)
+
+walkMap :: RepresentationMap Subject
+  -- domain:      NestedPath    (right-recursive path nesting)
+  -- codomain:    FlatEdgeList  (anonymous path + flat relationship list)
+```
+
+---
+
+## Relationship to pattern-equivalence
+
+`pattern-equivalence` handles two gram expressions that are syntactically different
+but structurally identical — the same `Pattern<Subject>`, the same kind of shape, no
+named mapping required. This happens at parse time.
+
+`RepresentationMap` handles two patterns of *different* kinds of shape that are
+informationally equivalent under declared conventions. The nesting depth, arity, and
+topology differ between kinds; the conventions define the correspondence and the
+`roundTrip` property witnesses it.
+
+---
+
+## The two-register model
+
+`RepresentationMap` formalises a recurring design choice: the same information can be
+held in a form optimised for reading or a form optimised for querying.
+
+- **Pattern form** — nesting makes local structure immediately visible. Optimised for
+  authoring, reading, and sequential processing by humans and LLMs top-to-bottom.
+- **Graph form** — flat topology makes global structure immediately traversable.
+  Optimised for querying, graph algorithms, and integration with graph-native tools.
+
+Graph form is not a privileged target. It is one codomain among many. The choice is a
+deployment concern, made explicit and reversible by naming the kinds and declaring the
+map.
+
+---
+
+## Concrete example: diagnostic map
+
+**Kinds:**
+- `DiagnosticPattern` — kind predicate: location pattern directly containing a
+  diagnostic pattern directly containing zero or more remediation patterns; labels
+  `Location`, `Diagnostic`, `Remediation`; specific required properties per label.
+- `DiagnosticGraph` — kind predicate: flat atomic patterns with labels `Location`,
+  `Diagnostic`, `Remediation`; connected by `AT` and `HAS_REMEDIATION` relationships;
+  `_arity` and `_depth` properties present on each.
+
+**Conventions:**
+- `_arity` on each graph-form node encodes the element count of the corresponding
+  nested pattern node, enabling the inverse to reconstruct arity.
+- `_depth` encodes nesting depth, enabling the inverse to reconstruct order.
+
+**Forward** (`DiagnosticPattern` → `DiagnosticGraph`): traverse the nested structure
+using `paraWithScope` (with `ScopeQuery` constraint — no graph topology needed here),
+emit flat patterns with `_arity`/`_depth` properties, connect with typed
+relationships. Use `byIdentity` to resolve cross-references.
+
+**Inverse** (`DiagnosticGraph` → `DiagnosticPattern`): find all `Diagnostic` patterns
+via `allElements`, traverse edges using `containers`, reconstruct nesting from
+`_arity`/`_depth` properties, emit the nested pattern.
+
+**Round-trip property**: for all `p` satisfying `kindPred DiagnosticPattern q p`,
+`(inverse q . forward q) p == p` structurally.
+
+---
+
+## Implementation sequence
+
+**Step 1 — Haskell prototype** (`pattern-hs`)
+
+Prerequisites: `GraphTransform` proposal implemented.
+
+- Define `ScopeQuery` typeclass and `TrivialScope` instance in `Pattern.Core`
+- Define `GraphScope` typeclass as subclass of `ScopeQuery` in `Pattern.Graph`
+- Add `ScopeQuery` and `GraphScope` instances for `GraphQuery` in `Pattern.Graph`
+- Add `paraWithScope` to `Pattern.Core`; redefine `para` and `paraGraph` in terms
+  of it; verify no behavioral change via existing tests
+- Define `PatternKind v` and `RepresentationMap v`; implement `compose`
+- Define `diagnosticMap` with declared kinds and conventions; write Hedgehog property
+  tests: for all `p` satisfying `kindPred (domain m) q p`, `roundTrip q m p` holds
+  and `kindPred (codomain m) q (forward q p)` holds
+- Write composition tests: `roundTrip` holds for composed maps
+- If any transform requires a constraint beyond `ScopeQuery` (e.g. needs `GraphScope`
+  for graph-sourced maps), express this as a typeclass constraint on the transform
+  function; the `RepresentationMap` record's `forward`/`inverse` fields use `forall q`
+  but individual helper functions may be more constrained
+
+**Step 2 — Rust port** (`pattern-rs`)
+
+The typeclass hierarchy maps to a trait hierarchy:
+
+```rust
+pub trait ScopeQuery<V: GraphValue> {
+    fn containers(&self, p: &Pattern<V>) -> Vec<Pattern<V>>;
+    fn siblings(&self, p: &Pattern<V>) -> Vec<Pattern<V>>;
+    fn by_identity(&self, id: &V::Id) -> Option<Pattern<V>>;
+    fn all_elements(&self) -> Vec<Pattern<V>>;
+}
+
+pub trait GraphScope<V: GraphValue>: ScopeQuery<V> {
+    fn source(&self, p: &Pattern<V>) -> Option<Pattern<V>>;
+    fn target(&self, p: &Pattern<V>) -> Option<Pattern<V>>;
+    fn incidents(&self, p: &Pattern<V>) -> Vec<Pattern<V>>;
+    fn degree(&self, p: &Pattern<V>) -> usize;
+}
+
+pub struct PatternKind<V: GraphValue> {
+    pub name:    String,
+    pub pred:    Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> bool>,
+    pub example: Pattern<V>,
+}
+
+pub struct RepresentationMap<V: GraphValue> {
+    pub name:        String,
+    pub domain:      PatternKind<V>,
+    pub codomain:    PatternKind<V>,
+    pub conventions: Vec<String>,
+    pub forward:     Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> Pattern<V>>,
+    pub inverse:     Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> Pattern<V>>,
+    pub round_trip:  Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> bool>,
+}
+```
+
+`Arc` / `Rc` feature flag applies throughout. Graph-topology-aware transforms accept
+`&dyn GraphScope<V>` rather than `&dyn ScopeQuery<V>`.
+
+**Step 3 — Pato surface** (`pato canonicalize`)
+
+```
+pato canonicalize [--map <n>] [--inverse] <files>...
+```
+
+- `--map` selects a named `RepresentationMap` from the library
+- `--inverse` applies the inverse transform
+- Default map: inferred from the document `kind` header
+- Scope constructed by pato from the document being transformed
+- Output is gram on stdout; errors on stderr
+
+The library owns the capability. Pato is a thin surface.
+
+---
+
+## Open questions for the Haskell prototype
+
+**1. Typeclass interface with dictionary convenience — see §"Interface convention"**
+
+The approach for `ScopeQuery` as a typeclass, the `ScopeDict` first-class value form,
+and the treatment of existing records is fully specified in the "Interface convention"
+section above. This is no longer an open question.
+
+**2. Kind compatibility in compose**
+
+`compose m1 m2` requires `codomain m1` and `domain m2` to be compatible. In the
+prototype this is a runtime check (`kindName (codomain m1) == kindName (domain m2)`
+or a predicate-subsumption check). Phantom type tags would make it compile-time but
+require kinds to be named at the type level. Defer until the abstraction is stable.
+
+**3. RepresentationMap as a pattern**
+
+Can a `RepresentationMap` itself be represented as a `Pattern<V>`? If so, it could be
+serialized to gram like any other pattern — stored, transmitted, inspected with pato,
+and composed at the data level rather than only at the code level.
+
+This is an open question about the data model, not about file organization or tooling.
+Gram is a serialization format for patterns; the question is whether `RepresentationMap`
+— including its domain, codomain, conventions, and the structural rules that relate
+them — has a natural representation as a `Pattern<V>`. The `forward` and `inverse`
+functions are code and cannot be serialized directly, but the *description* of what
+they do — the kinds they operate between and the conventions that make the round-trip
+work — may be pattern-representable.
+
+If a `RepresentationMap` is pattern-representable, then gram becomes the lingua franca
+for describing mappings as well as data, and `pato` can inspect and validate mappings
+using the same machinery it uses for everything else. If it is not — if some essential
+part of a mapping is irreducibly procedural — that is also a useful conclusion, and
+the boundary between the declarative and procedural parts is worth identifying
+precisely.
+
+Park until after the Haskell prototype has at least two concrete maps implemented and
+their structure is well understood.
+
+---
+
+## Related documents
+
+- `proposals/graph-transform.md` — primitive operations that `RepresentationMap`
+  builds on; `ScopeQuery` and `GraphScope` typeclasses imply additive changes here
+- `proposals/graph-query.md` — `GraphQuery` gains `ScopeQuery` and `GraphScope`
+  instances; existing record fields become the implementations
+- `proposals/pattern-equivalence.md` — syntactic equivalence (same kind, different
+  notation); distinct from `RepresentationMap` (different kinds)
+- `proposals/pato-feature-proposal.md` — `pato canonicalize` surfaces
+  `RepresentationMap`; motivated this design
+- `proposals/graph-classifier.md` — existing record-of-functions pattern; gains
+  typeclass instances under the convention established in §"Interface convention";
+  the `*Dict` / instance pattern applies to all future interfaces

--- a/specs/039-representation-map/checklists/requirements.md
+++ b/specs/039-representation-map/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: RepresentationMap
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-17
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+All items pass. Spec is ready for `/speckit.plan`.
+
+Key design decisions encoded in Assumptions:
+- Runtime kind-compat check in `compose` (phantom types deferred)
+- `GraphScope` typeclass deferred until a concrete map requires graph topology
+- RepresentationMap-as-Pattern question parked until two concrete maps exist

--- a/specs/039-representation-map/contracts/Pattern.Core.hs
+++ b/specs/039-representation-map/contracts/Pattern.Core.hs
@@ -1,0 +1,50 @@
+-- Contract: Pattern.Core additions for 039-representation-map
+-- These declarations are added to the existing Pattern.Core module.
+-- Existing exports (ScopeQuery, TrivialScope, ScopeDict, paraWithScope, para, etc.) are unchanged.
+
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+
+module Pattern.Core
+  ( -- ... existing exports unchanged ...
+
+    -- * Shape kinds (039-representation-map)
+    PatternKind(..)
+  , checkKind
+
+  ) where
+
+-- | A named, scope-aware description of a family of Pattern shapes.
+--
+-- A @PatternKind@ is a subobject classifier for @Pattern v@: it defines a
+-- subtype via a predicate. The @kindExample@ witnesses non-emptiness of the kind.
+--
+-- Categorical note: @kindPred@ is the characteristic morphism of the subobject.
+-- @kindExample@ is an element of the represented subtype — it MUST satisfy
+-- @kindPred@ for any valid scope.
+--
+-- Usage:
+--   diagnosticKind :: PatternKind Subject
+--   diagnosticKind = PatternKind
+--     { kindName    = "DiagnosticPattern"
+--     , kindPred    = \q p -> hasLabel "Location" p && ...
+--     , kindExample = exampleDiagnosticPattern
+--     }
+data PatternKind v = PatternKind
+  { kindName    :: String
+    -- ^ Unique human-readable name for this kind. Used for kind-compat checks in compose.
+  , kindPred    :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ Membership predicate. Polymorphic over scope: structural predicates ignore the
+    -- scope; scope-relative predicates use containers/byIdentity/allElements.
+  , kindExample :: Pattern v
+    -- ^ Canonical example. MUST satisfy kindPred for any valid scope.
+    -- Used for smoke tests and property-based test generation seeds.
+  }
+
+-- | Check whether a pattern is of a given kind within a scope.
+--
+-- Convenience wrapper: @checkKind k q p = kindPred k q p@.
+checkKind :: ScopeQuery q v => PatternKind v -> q v -> Pattern v -> Bool
+checkKind k q p = kindPred k q p

--- a/specs/039-representation-map/contracts/Pattern.RepresentationMap.hs
+++ b/specs/039-representation-map/contracts/Pattern.RepresentationMap.hs
@@ -18,10 +18,9 @@ import Pattern.Core (Pattern, ScopeQuery, PatternKind, kindName)
 -- @forward@ and @inverse@ are the two morphism components. @roundTrip@ witnesses
 -- the identity law: @(inverse q . forward q) p == p@ for all domain-kind patterns.
 --
--- The @conventions@ field documents the structural decisions that make invertibility
--- possible. For example, if the forward transform encodes nesting depth as a @_depth@
--- property on output patterns, that encoding convention must be listed here so that
--- the inverse can rely on it.
+-- Explanatory notes about how a concrete map works are intentionally kept outside the
+-- runtime value for now. The current design stores executable behavior and the
+-- round-trip witness only; declarative, machine-checkable map claims are deferred.
 --
 -- Usage:
 --   myMap :: RepresentationMap Subject
@@ -29,7 +28,6 @@ import Pattern.Core (Pattern, ScopeQuery, PatternKind, kindName)
 --     { name        = "MyMap"
 --     , domain      = nestedKind
 --     , codomain    = flatKind
---     , conventions = ["_arity encodes element count", "_depth encodes nesting depth"]
 --     , forward     = \q p -> ...
 --     , inverse     = \q p -> ...
 --     , roundTrip   = \q p -> (inverse myMap q . forward myMap q) p == p
@@ -41,9 +39,6 @@ data RepresentationMap v = RepresentationMap
     -- ^ The source kind. @forward@ is only defined on patterns satisfying this kind.
   , codomain    :: PatternKind v
     -- ^ The target kind. @forward@ MUST produce patterns satisfying this kind.
-  , conventions :: [String]
-    -- ^ Named structural decisions that enable invertibility.
-    -- Each entry names one encoding decision made by @forward@ that @inverse@ depends on.
   , forward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
     -- ^ The forward transform: domain kind → codomain kind.
     -- Polymorphic over scope: may use containers, allElements, byIdentity.
@@ -66,7 +61,6 @@ data RepresentationMap v = RepresentationMap
 -- - Name:        @name m1 <> " >>> " <> name m2@
 -- - Domain:      @domain m1@
 -- - Codomain:    @codomain m2@
--- - Conventions: @conventions m1 <> conventions m2@
 -- - Forward:     @forward m2 q . forward m1 q@
 -- - Inverse:     @inverse m1 q . inverse m2 q@
 -- - RoundTrip:   @roundTrip m1 q p && roundTrip m2 q (forward m1 q p)@
@@ -84,7 +78,6 @@ compose m1 m2
       { name        = name m1 <> " >>> " <> name m2
       , domain      = domain m1
       , codomain    = codomain m2
-      , conventions = conventions m1 <> conventions m2
       , forward     = \q p -> forward m2 q (forward m1 q p)
       , inverse     = \q p -> inverse m1 q (inverse m2 q p)
       , roundTrip   = \q p -> roundTrip m1 q p && roundTrip m2 q (forward m1 q p)

--- a/specs/039-representation-map/contracts/Pattern.RepresentationMap.hs
+++ b/specs/039-representation-map/contracts/Pattern.RepresentationMap.hs
@@ -1,0 +1,91 @@
+-- Contract: Pattern.RepresentationMap — new module for 039-representation-map
+--
+-- New module added to the Pattern library alongside Pattern.Core and Pattern.Graph.*.
+
+{-# LANGUAGE RankNTypes #-}
+
+module Pattern.RepresentationMap
+  ( -- * Representation maps
+    RepresentationMap(..)
+  , compose
+  ) where
+
+import Pattern.Core (Pattern, ScopeQuery, PatternKind, kindName)
+
+-- | A named, invertible, composable isomorphism between two kinds of Pattern shape.
+--
+-- A @RepresentationMap@ is a named isomorphism in the category of @PatternKind@s.
+-- @forward@ and @inverse@ are the two morphism components. @roundTrip@ witnesses
+-- the identity law: @(inverse q . forward q) p == p@ for all domain-kind patterns.
+--
+-- The @conventions@ field documents the structural decisions that make invertibility
+-- possible. For example, if the forward transform encodes nesting depth as a @_depth@
+-- property on output patterns, that encoding convention must be listed here so that
+-- the inverse can rely on it.
+--
+-- Usage:
+--   myMap :: RepresentationMap Subject
+--   myMap = RepresentationMap
+--     { name        = "MyMap"
+--     , domain      = nestedKind
+--     , codomain    = flatKind
+--     , conventions = ["_arity encodes element count", "_depth encodes nesting depth"]
+--     , forward     = \q p -> ...
+--     , inverse     = \q p -> ...
+--     , roundTrip   = \q p -> (inverse myMap q . forward myMap q) p == p
+--     }
+data RepresentationMap v = RepresentationMap
+  { name        :: String
+    -- ^ Unique human-readable name for this map, e.g. "DiagnosticMap".
+  , domain      :: PatternKind v
+    -- ^ The source kind. @forward@ is only defined on patterns satisfying this kind.
+  , codomain    :: PatternKind v
+    -- ^ The target kind. @forward@ MUST produce patterns satisfying this kind.
+  , conventions :: [String]
+    -- ^ Named structural decisions that enable invertibility.
+    -- Each entry names one encoding decision made by @forward@ that @inverse@ depends on.
+  , forward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+    -- ^ The forward transform: domain kind → codomain kind.
+    -- Polymorphic over scope: may use containers, allElements, byIdentity.
+    -- MUST produce a result satisfying @kindPred (codomain m) q result@.
+  , inverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+    -- ^ The inverse transform: codomain kind → domain kind.
+    -- MUST satisfy: for all p of domain kind, @(inverse q . forward q) p == p@.
+  , roundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ Isomorphism witness. MUST hold for all p satisfying @kindPred (domain m) q p@.
+    -- Canonical implementation: @\q p -> (inverse q . forward q) p == p@
+    -- (requires Eq v; callers may substitute structural equality checks).
+  }
+
+-- | Compose two compatible @RepresentationMap@s into a single map.
+--
+-- @compose m1 m2@ requires @kindName (codomain m1) == kindName (domain m2)@.
+-- Returns @Left@ with a descriptive error if the kinds are incompatible.
+--
+-- The composed map:
+-- - Name:        @name m1 <> " >>> " <> name m2@
+-- - Domain:      @domain m1@
+-- - Codomain:    @codomain m2@
+-- - Conventions: @conventions m1 <> conventions m2@
+-- - Forward:     @forward m2 q . forward m1 q@
+-- - Inverse:     @inverse m1 q . inverse m2 q@
+-- - RoundTrip:   @roundTrip m1 q p && roundTrip m2 q (forward m1 q p)@
+--
+-- Categorical note: @compose@ is morphism composition in the category of PatternKinds.
+-- Associativity holds: @compose (compose a b) c == compose a (compose b c)@ (up to name).
+compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)
+compose m1 m2
+  | kindName (codomain m1) /= kindName (domain m2) =
+      Left $ "compose: codomain of '" <> name m1
+          <> "' (" <> kindName (codomain m1)
+          <> ") does not match domain of '" <> name m2
+          <> "' (" <> kindName (domain m2) <> ")"
+  | otherwise = Right RepresentationMap
+      { name        = name m1 <> " >>> " <> name m2
+      , domain      = domain m1
+      , codomain    = codomain m2
+      , conventions = conventions m1 <> conventions m2
+      , forward     = \q p -> forward m2 q (forward m1 q p)
+      , inverse     = \q p -> inverse m1 q (inverse m2 q p)
+      , roundTrip   = \q p -> roundTrip m1 q p && roundTrip m2 q (forward m1 q p)
+      }

--- a/specs/039-representation-map/contracts/Pattern.RepresentationMap.hs
+++ b/specs/039-representation-map/contracts/Pattern.RepresentationMap.hs
@@ -15,8 +15,9 @@ import Pattern.Core (Pattern, ScopeQuery, PatternKind, kindName)
 -- | A named, invertible, composable isomorphism between two kinds of Pattern shape.
 --
 -- A @RepresentationMap@ is a named isomorphism in the category of @PatternKind@s.
--- @forward@ and @inverse@ are the two morphism components. @roundTrip@ witnesses
--- the identity law: @(inverse q . forward q) p == p@ for all domain-kind patterns.
+-- @repMapForward@ and @repMapInverse@ are the two morphism components.
+-- @repMapRoundTrip@ witnesses the identity law:
+-- @(repMapInverse q . repMapForward q) p == p@ for all domain-kind patterns.
 --
 -- Explanatory notes about how a concrete map works are intentionally kept outside the
 -- runtime value for now. The current design stores executable behavior and the
@@ -25,60 +26,61 @@ import Pattern.Core (Pattern, ScopeQuery, PatternKind, kindName)
 -- Usage:
 --   myMap :: RepresentationMap Subject
 --   myMap = RepresentationMap
---     { name        = "MyMap"
---     , domain      = nestedKind
---     , codomain    = flatKind
---     , forward     = \q p -> ...
---     , inverse     = \q p -> ...
---     , roundTrip   = \q p -> (inverse myMap q . forward myMap q) p == p
+--     { repMapName        = "MyMap"
+--     , repMapDomain      = nestedKind
+--     , repMapCodomain    = flatKind
+--     , repMapForward     = \q p -> ...
+--     , repMapInverse     = \q p -> ...
+--     , repMapRoundTrip   = \q p -> (repMapInverse myMap q . repMapForward myMap q) p == p
 --     }
 data RepresentationMap v = RepresentationMap
-  { name        :: String
+  { repMapName        :: String
     -- ^ Unique human-readable name for this map, e.g. "DiagnosticMap".
-  , domain      :: PatternKind v
-    -- ^ The source kind. @forward@ is only defined on patterns satisfying this kind.
-  , codomain    :: PatternKind v
-    -- ^ The target kind. @forward@ MUST produce patterns satisfying this kind.
-  , forward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , repMapDomain      :: PatternKind v
+    -- ^ The source kind. @repMapForward@ is only defined on patterns satisfying this kind.
+  , repMapCodomain    :: PatternKind v
+    -- ^ The target kind. @repMapForward@ MUST produce patterns satisfying this kind.
+  , repMapForward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
     -- ^ The forward transform: domain kind → codomain kind.
     -- Polymorphic over scope: may use containers, allElements, byIdentity.
-    -- MUST produce a result satisfying @kindPred (codomain m) q result@.
-  , inverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+    -- MUST produce a result satisfying @kindPred (repMapCodomain m) q result@.
+  , repMapInverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
     -- ^ The inverse transform: codomain kind → domain kind.
-    -- MUST satisfy: for all p of domain kind, @(inverse q . forward q) p == p@.
-  , roundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
-    -- ^ Isomorphism witness. MUST hold for all p satisfying @kindPred (domain m) q p@.
-    -- Canonical implementation: @\q p -> (inverse q . forward q) p == p@
+    -- MUST satisfy: for all p of domain kind, @(repMapInverse q . repMapForward q) p == p@.
+  , repMapRoundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ Isomorphism witness. MUST hold for all p satisfying @kindPred (repMapDomain m) q p@.
+    -- Canonical implementation: @\q p -> (repMapInverse q . repMapForward q) p == p@
     -- (requires Eq v; callers may substitute structural equality checks).
   }
 
 -- | Compose two compatible @RepresentationMap@s into a single map.
 --
--- @compose m1 m2@ requires @kindName (codomain m1) == kindName (domain m2)@.
+-- @compose m1 m2@ requires
+-- @kindName (repMapCodomain m1) == kindName (repMapDomain m2)@.
 -- Returns @Left@ with a descriptive error if the kinds are incompatible.
 --
 -- The composed map:
--- - Name:        @name m1 <> " >>> " <> name m2@
--- - Domain:      @domain m1@
--- - Codomain:    @codomain m2@
--- - Forward:     @forward m2 q . forward m1 q@
--- - Inverse:     @inverse m1 q . inverse m2 q@
--- - RoundTrip:   @roundTrip m1 q p && roundTrip m2 q (forward m1 q p)@
+-- - Name:        @repMapName m1 <> " >>> " <> repMapName m2@
+-- - Domain:      @repMapDomain m1@
+-- - Codomain:    @repMapCodomain m2@
+-- - Forward:     @repMapForward m2 q . repMapForward m1 q@
+-- - Inverse:     @repMapInverse m1 q . repMapInverse m2 q@
+-- - RoundTrip:   @repMapRoundTrip m1 q p && repMapRoundTrip m2 q (repMapForward m1 q p)@
 --
 -- Categorical note: @compose@ is morphism composition in the category of PatternKinds.
--- Associativity holds: @compose (compose a b) c == compose a (compose b c)@ (up to name).
+-- Associativity holds: @compose (compose a b) c == compose a (compose b c)@ (up to repMapName).
 compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)
 compose m1 m2
-  | kindName (codomain m1) /= kindName (domain m2) =
-      Left $ "compose: codomain of '" <> name m1
-          <> "' (" <> kindName (codomain m1)
-          <> ") does not match domain of '" <> name m2
-          <> "' (" <> kindName (domain m2) <> ")"
+  | kindName (repMapCodomain m1) /= kindName (repMapDomain m2) =
+      Left $ "compose: codomain of '" <> repMapName m1
+          <> "' (" <> kindName (repMapCodomain m1)
+          <> ") does not match domain of '" <> repMapName m2
+          <> "' (" <> kindName (repMapDomain m2) <> ")"
   | otherwise = Right RepresentationMap
-      { name        = name m1 <> " >>> " <> name m2
-      , domain      = domain m1
-      , codomain    = codomain m2
-      , forward     = \q p -> forward m2 q (forward m1 q p)
-      , inverse     = \q p -> inverse m1 q (inverse m2 q p)
-      , roundTrip   = \q p -> roundTrip m1 q p && roundTrip m2 q (forward m1 q p)
+      { repMapName        = repMapName m1 <> " >>> " <> repMapName m2
+      , repMapDomain      = repMapDomain m1
+      , repMapCodomain    = repMapCodomain m2
+      , repMapForward     = \q p -> repMapForward m2 q (repMapForward m1 q p)
+      , repMapInverse     = \q p -> repMapInverse m1 q (repMapInverse m2 q p)
+      , repMapRoundTrip   = \q p -> repMapRoundTrip m1 q p && repMapRoundTrip m2 q (repMapForward m1 q p)
       }

--- a/specs/039-representation-map/data-model.md
+++ b/specs/039-representation-map/data-model.md
@@ -34,7 +34,6 @@ RepresentationMap v
   name        :: String               -- e.g. "DiagnosticMap"
   domain      :: PatternKind v        -- source kind
   codomain    :: PatternKind v        -- target kind
-  conventions :: [String]             -- named structural decisions enabling invertibility
   forward     :: ∀q. ScopeQuery q v   -- domain → codomain transform
                 => q v -> Pattern v -> Pattern v
   inverse     :: ∀q. ScopeQuery q v   -- codomain → domain transform
@@ -54,14 +53,12 @@ RepresentationMap v
 
 ### `Convention`
 
-A named structural decision that the forward transform encodes into the codomain and the inverse relies on to reconstruct the domain.
+A future design area, not part of the current runtime data model.
 
-```
-Convention = String     -- e.g. "_arity encodes element count"
-                        --      "_depth encodes nesting depth"
-```
-
-Conventions are part of a map's identity. Two maps with identical `forward` functions but different encoding decisions are different maps with different inverses.
+Encoding choices such as `_arity` or `_depth` may still matter to a concrete map,
+but they are currently documented beside the implementation and exercised through
+kind checks and round-trip tests rather than stored as inline prose on the
+`RepresentationMap` value.
 
 ---
 
@@ -75,16 +72,15 @@ compose :: RepresentationMap v -> RepresentationMap v -> Either String (Represen
 **Failure**: `Left` with message identifying the mismatch if precondition not met
 **Result**: A map from `domain m1` to `codomain m2` with:
 - `name = name m1 <> " >>> " <> name m2`
-- `conventions = conventions m1 <> conventions m2`
 - `forward q = forward m2 q . forward m1 q`
 - `inverse q = inverse m1 q . inverse m2 q`
-- `roundTrip q p = roundTrip m1 q p && roundTrip m2 q p`
+- `roundTrip q p = roundTrip m1 q p && roundTrip m2 q (forward m1 q p)`
 
-**Categorical interpretation**: `compose` is morphism composition in the category of `PatternKind`s. The `Either` wraps a partial function — composition is only defined when codomain matches domain. The convention union records the chain of structural decisions.
+**Categorical interpretation**: `compose` is morphism composition in the category of `PatternKind`s. The `Either` wraps a partial function — composition is only defined when codomain matches domain.
 
 ---
 
-## Concrete Kinds for `diagnosticMap`
+## Concrete Kinds for the `diagnosticMap` Test Example
 
 ### `DiagnosticPattern`
 

--- a/specs/039-representation-map/data-model.md
+++ b/specs/039-representation-map/data-model.md
@@ -1,0 +1,137 @@
+# Data Model: RepresentationMap (039)
+
+**Date**: 2026-03-17
+**Branch**: `039-representation-map`
+
+---
+
+## Core Types
+
+### `PatternKind v`
+
+A named, scope-aware description of a family of patterns. Not an individual pattern — the description of what structural constraints a pattern must satisfy to be considered an instance of that kind.
+
+```
+PatternKind v
+  kindName    :: String               -- unique human-readable name, e.g. "DiagnosticPattern"
+  kindPred    :: ∀q. ScopeQuery q v   -- true iff pattern is of this kind within a scope
+                => q v -> Pattern v -> Bool
+  kindExample :: Pattern v            -- canonical example; always satisfies kindPred
+```
+
+**Invariant**: `kindPred q (kindExample k) == True` for any valid scope `q`.
+
+**Categorical interpretation**: A `PatternKind v` is a subobject classifier for `Pattern v` — it defines a subtype of `Pattern v` via a predicate. The `kindPred` is a characteristic morphism. The `kindExample` witnesses non-emptiness of the kind.
+
+---
+
+### `RepresentationMap v`
+
+A named, invertible, composable isomorphism between two kinds of shape. The round-trip field is the machine-checkable witness to the isomorphism.
+
+```
+RepresentationMap v
+  name        :: String               -- e.g. "DiagnosticMap"
+  domain      :: PatternKind v        -- source kind
+  codomain    :: PatternKind v        -- target kind
+  conventions :: [String]             -- named structural decisions enabling invertibility
+  forward     :: ∀q. ScopeQuery q v   -- domain → codomain transform
+                => q v -> Pattern v -> Pattern v
+  inverse     :: ∀q. ScopeQuery q v   -- codomain → domain transform
+                => q v -> Pattern v -> Pattern v
+  roundTrip   :: ∀q. ScopeQuery q v   -- isomorphism witness
+                => q v -> Pattern v -> Bool
+```
+
+**Invariant**: For all `p` satisfying `kindPred (domain m) q p`:
+1. `kindPred (codomain m) q (forward m q p) == True`
+2. `roundTrip m q p == True`
+3. `roundTrip m q p` implies `(inverse m q . forward m q) p == p` structurally
+
+**Categorical interpretation**: A `RepresentationMap v` is a named isomorphism in the category of `PatternKind`s. `forward` and `inverse` are the two morphism components. `roundTrip` witnesses the identity law `inverse ∘ forward = id` on the domain subobject.
+
+---
+
+### `Convention`
+
+A named structural decision that the forward transform encodes into the codomain and the inverse relies on to reconstruct the domain.
+
+```
+Convention = String     -- e.g. "_arity encodes element count"
+                        --      "_depth encodes nesting depth"
+```
+
+Conventions are part of a map's identity. Two maps with identical `forward` functions but different encoding decisions are different maps with different inverses.
+
+---
+
+## Composition
+
+```
+compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)
+```
+
+**Precondition**: `kindName (codomain m1) == kindName (domain m2)`
+**Failure**: `Left` with message identifying the mismatch if precondition not met
+**Result**: A map from `domain m1` to `codomain m2` with:
+- `name = name m1 <> " >>> " <> name m2`
+- `conventions = conventions m1 <> conventions m2`
+- `forward q = forward m2 q . forward m1 q`
+- `inverse q = inverse m1 q . inverse m2 q`
+- `roundTrip q p = roundTrip m1 q p && roundTrip m2 q p`
+
+**Categorical interpretation**: `compose` is morphism composition in the category of `PatternKind`s. The `Either` wraps a partial function — composition is only defined when codomain matches domain. The convention union records the chain of structural decisions.
+
+---
+
+## Concrete Kinds for `diagnosticMap`
+
+### `DiagnosticPattern`
+
+A nested structure: a `Location` pattern directly containing a `Diagnostic` pattern, which directly contains zero or more `Remediation` patterns.
+
+**Predicate (informal)**: Pattern has label `"Location"` and `elements` contains exactly one sub-pattern with label `"Diagnostic"`, which in turn has zero or more sub-patterns with label `"Remediation"`.
+
+**Structural form**:
+```
+Location
+  Diagnostic
+    Remediation?
+    Remediation?
+    ...
+```
+
+### `DiagnosticGraph`
+
+A flat form: atomic patterns with labels `"Location"`, `"Diagnostic"`, `"Remediation"` connected by typed relationship patterns (`"AT"`, `"HAS_REMEDIATION"`), with `_arity` and `_depth` scalar properties on each.
+
+**Predicate (informal)**: All patterns are atomic (empty elements). Labels are constrained to `{"Location", "Diagnostic", "Remediation", "AT", "HAS_REMEDIATION"}`. Each non-relationship pattern has `_arity` and `_depth` numeric properties.
+
+---
+
+## Module Relationships
+
+```
+Pattern.Core
+  PatternKind v           -- new type
+  (ScopeQuery, TrivialScope, ScopeDict, paraWithScope — existing)
+
+Pattern.RepresentationMap
+  RepresentationMap v     -- new type
+  compose                 -- new function
+  (imports Pattern.Core)
+
+tests/Spec/Pattern/RepresentationMapSpec.hs
+  diagnosticPatternKind   -- DiagnosticPattern PatternKind
+  diagnosticGraphKind     -- DiagnosticGraph PatternKind
+  diagnosticMap           -- RepresentationMap between above
+  (QuickCheck round-trip properties)
+```
+
+---
+
+## State Transitions
+
+`RepresentationMap` has no mutable state. The types are pure values. Composition produces a new value; it does not modify the inputs.
+
+The only "state" is the validation result of `roundTrip`, which is a pure predicate over a domain-kind pattern.

--- a/specs/039-representation-map/data-model.md
+++ b/specs/039-representation-map/data-model.md
@@ -31,23 +31,23 @@ A named, invertible, composable isomorphism between two kinds of shape. The roun
 
 ```
 RepresentationMap v
-  name        :: String               -- e.g. "DiagnosticMap"
-  domain      :: PatternKind v        -- source kind
-  codomain    :: PatternKind v        -- target kind
-  forward     :: ∀q. ScopeQuery q v   -- domain → codomain transform
-                => q v -> Pattern v -> Pattern v
-  inverse     :: ∀q. ScopeQuery q v   -- codomain → domain transform
-                => q v -> Pattern v -> Pattern v
-  roundTrip   :: ∀q. ScopeQuery q v   -- isomorphism witness
-                => q v -> Pattern v -> Bool
+  repMapName        :: String               -- e.g. "DiagnosticMap"
+  repMapDomain      :: PatternKind v        -- source kind
+  repMapCodomain    :: PatternKind v        -- target kind
+  repMapForward     :: ∀q. ScopeQuery q v   -- domain → codomain transform
+                    => q v -> Pattern v -> Pattern v
+  repMapInverse     :: ∀q. ScopeQuery q v   -- codomain → domain transform
+                    => q v -> Pattern v -> Pattern v
+  repMapRoundTrip   :: ∀q. ScopeQuery q v   -- isomorphism witness
+                    => q v -> Pattern v -> Bool
 ```
 
-**Invariant**: For all `p` satisfying `kindPred (domain m) q p`:
-1. `kindPred (codomain m) q (forward m q p) == True`
-2. `roundTrip m q p == True`
-3. `roundTrip m q p` implies `(inverse m q . forward m q) p == p` structurally
+**Invariant**: For all `p` satisfying `kindPred (repMapDomain m) q p`:
+1. `kindPred (repMapCodomain m) q (repMapForward m q p) == True`
+2. `repMapRoundTrip m q p == True`
+3. `repMapRoundTrip m q p` implies `(repMapInverse m q . repMapForward m q) p == p` structurally
 
-**Categorical interpretation**: A `RepresentationMap v` is a named isomorphism in the category of `PatternKind`s. `forward` and `inverse` are the two morphism components. `roundTrip` witnesses the identity law `inverse ∘ forward = id` on the domain subobject.
+**Categorical interpretation**: A `RepresentationMap v` is a named isomorphism in the category of `PatternKind`s. `repMapForward` and `repMapInverse` are the two morphism components. `repMapRoundTrip` witnesses the identity law `repMapInverse ∘ repMapForward = id` on the domain subobject.
 
 ---
 
@@ -68,13 +68,13 @@ kind checks and round-trip tests rather than stored as inline prose on the
 compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)
 ```
 
-**Precondition**: `kindName (codomain m1) == kindName (domain m2)`
+**Precondition**: `kindName (repMapCodomain m1) == kindName (repMapDomain m2)`
 **Failure**: `Left` with message identifying the mismatch if precondition not met
-**Result**: A map from `domain m1` to `codomain m2` with:
-- `name = name m1 <> " >>> " <> name m2`
-- `forward q = forward m2 q . forward m1 q`
-- `inverse q = inverse m1 q . inverse m2 q`
-- `roundTrip q p = roundTrip m1 q p && roundTrip m2 q (forward m1 q p)`
+**Result**: A map from `repMapDomain m1` to `repMapCodomain m2` with:
+- `repMapName = repMapName m1 <> " >>> " <> repMapName m2`
+- `repMapForward q = repMapForward m2 q . repMapForward m1 q`
+- `repMapInverse q = repMapInverse m1 q . repMapInverse m2 q`
+- `repMapRoundTrip q p = repMapRoundTrip m1 q p && repMapRoundTrip m2 q (repMapForward m1 q p)`
 
 **Categorical interpretation**: `compose` is morphism composition in the category of `PatternKind`s. The `Either` wraps a partial function — composition is only defined when codomain matches domain.
 
@@ -130,4 +130,4 @@ tests/Spec/Pattern/RepresentationMapSpec.hs
 
 `RepresentationMap` has no mutable state. The types are pure values. Composition produces a new value; it does not modify the inputs.
 
-The only "state" is the validation result of `roundTrip`, which is a pure predicate over a domain-kind pattern.
+The only "state" is the validation result of `repMapRoundTrip`, which is a pure predicate over a domain-kind pattern.

--- a/specs/039-representation-map/plan.md
+++ b/specs/039-representation-map/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Introduce `PatternKind` (named, scope-aware shape predicates) in `Pattern.Core` and `RepresentationMap` (named invertible isomorphisms between shape kinds) in a new `Pattern.RepresentationMap` module. Add a concrete `diagnosticMap` instance in the test suite with QuickCheck round-trip property tests. All existing APIs are unchanged.
+Introduce `PatternKind` (named, scope-aware shape predicates) in `Pattern.Core` and `RepresentationMap` (named invertible isomorphisms between shape kinds) in a new `Pattern.RepresentationMap` module. Add a concrete `diagnosticMap` test/example in the test suite with QuickCheck round-trip property tests. All existing APIs are unchanged.
 
 ## Technical Context
 
@@ -28,7 +28,7 @@ Introduce `PatternKind` (named, scope-aware shape predicates) in `Pattern.Core` 
 | I. Code Quality | ✅ PASS | New types and functions will have explicit documentation with categorical interpretation |
 | II. Testing Standards | ✅ PASS | `PatternKind` and `RepresentationMap` will have unit tests; round-trip is a QuickCheck property; compose failure case is unit-tested |
 | III. Conceptual Consistency | ✅ PASS | `PatternKind` is a subobject classifier; `RepresentationMap` is a named isomorphism; `compose` is morphism composition — all documented with categorical interpretation |
-| IV. Mathematical Clarity | ✅ PASS | `roundTrip` is the formal isomorphism witness; identity law stated in contract; conventions make the inverse explicit |
+| IV. Mathematical Clarity | ✅ PASS | `roundTrip` is the formal isomorphism witness; identity law stated in contract; concrete encoding choices remain documented beside implementations |
 | V. Multi-Language Reference Alignment | ✅ PASS | Rust correspondence documented in proposal: typeclass→trait, `*Dict`→struct, `forall q`→`Box<dyn ScopeQuery<V>>` |
 | Version Control Standards | ✅ PASS | Intermediate commits per step: after PatternKind, after RepresentationMap, after diagnosticMap |
 
@@ -106,7 +106,7 @@ libs/pattern/tests/
 **Tests**:
 - T005: `compose` with compatible kinds produces map from domain-of-first to codomain-of-second
 - T006: `compose` combined `name` uses " >>> " separator
-- T007: `compose` combined `conventions` is union of both
+- T007: `compose` preserves the documented composition order and combined round-trip behavior
 - T008: `compose` returns `Left` when `kindName (codomain m1) /= kindName (domain m2)` — error message names both kinds
 - T009: composed `forward` applies m1 then m2
 - T010: composed `inverse` applies m2-inverse then m1-inverse
@@ -123,9 +123,9 @@ libs/pattern/tests/
 - `DiagnosticPattern`: `Location` pattern directly containing a `Diagnostic` pattern, which directly contains zero or more `Remediation` patterns
 - `DiagnosticGraph`: flat atomic patterns with labels `Location`, `Diagnostic`, `Remediation` connected by `AT`/`HAS_REMEDIATION` relationship patterns; each non-relationship pattern has `_arity` (Int) and `_depth` (Int) properties
 
-**Conventions** (the structural decisions that make inversion possible):
+**Encoding choices** (the structural decisions that make inversion possible):
 - `"_arity encodes element count of the corresponding nested pattern node"`
-- `"_depth encodes nesting depth, enabling reconstruction of order"`
+- `"_depth encodes nesting depth for graph-form nodes and validation"`
 
 **Forward transform** (DiagnosticPattern → DiagnosticGraph):
 - Traverse the nested structure with `paraWithScope` and `TrivialScope`
@@ -138,7 +138,7 @@ libs/pattern/tests/
 - Find all `Diagnostic` patterns via `allElements` on scope
 - Find their `Location` containers via `containers`
 - Find their `Remediation` children via `allElements` filtered by `HAS_REMEDIATION`
-- Reconstruct nesting order from `_depth` property
+- Preserve the graph's existing remediation encounter order while stripping graph metadata
 - Emit nested `Pattern` structure
 
 **Tests**:
@@ -147,7 +147,7 @@ libs/pattern/tests/
 - T013: round-trip on canonical example: `(inverse . forward) canonicalDiagnostic == canonicalDiagnostic`
 - T014: QuickCheck property — `forAll` generated `DiagnosticPattern`s, `roundTrip` holds
 - T015: QuickCheck property — after `compose diagnosticMap identityMap`, round-trip still holds (composition preserves correctness)
-- T016: `diagnosticMap` conventions list is non-empty and contains `"_arity"` and `"_depth"`
+- T016: `diagnosticMap` documents `_arity` and `_depth` usage beside the implementation and passes round-trip validation
 
 **Checkpoint commit**: `"representation-map: diagnosticMap prototype and round-trip tests"`
 

--- a/specs/039-representation-map/plan.md
+++ b/specs/039-representation-map/plan.md
@@ -1,0 +1,192 @@
+# Implementation Plan: RepresentationMap
+
+**Branch**: `039-representation-map` | **Date**: 2026-03-17 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/039-representation-map/spec.md`
+
+## Summary
+
+Introduce `PatternKind` (named, scope-aware shape predicates) in `Pattern.Core` and `RepresentationMap` (named invertible isomorphisms between shape kinds) in a new `Pattern.RepresentationMap` module. Add a concrete `diagnosticMap` instance in the test suite with QuickCheck round-trip property tests. All existing APIs are unchanged.
+
+## Technical Context
+
+**Language/Version**: Haskell (GHC 9.12.2)
+**Primary Dependencies**: base, containers — no new dependencies required
+**Storage**: N/A — pure in-memory types
+**Testing**: HSpec + QuickCheck (existing test suite)
+**Target Platform**: Library (no platform target)
+**Project Type**: Single library project
+**Performance Goals**: No hot-path concerns — `PatternKind` and `RepresentationMap` are data values, not traversal primitives
+**Constraints**: No new library dependencies; `RankNTypes` extension required
+**Scale/Scope**: Two new types, one new function, one new module, one new test file
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked post-design.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I. Code Quality | ✅ PASS | New types and functions will have explicit documentation with categorical interpretation |
+| II. Testing Standards | ✅ PASS | `PatternKind` and `RepresentationMap` will have unit tests; round-trip is a QuickCheck property; compose failure case is unit-tested |
+| III. Conceptual Consistency | ✅ PASS | `PatternKind` is a subobject classifier; `RepresentationMap` is a named isomorphism; `compose` is morphism composition — all documented with categorical interpretation |
+| IV. Mathematical Clarity | ✅ PASS | `roundTrip` is the formal isomorphism witness; identity law stated in contract; conventions make the inverse explicit |
+| V. Multi-Language Reference Alignment | ✅ PASS | Rust correspondence documented in proposal: typeclass→trait, `*Dict`→struct, `forall q`→`Box<dyn ScopeQuery<V>>` |
+| Version Control Standards | ✅ PASS | Intermediate commits per step: after PatternKind, after RepresentationMap, after diagnosticMap |
+
+**No violations. No complexity tracking required.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/039-representation-map/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   ├── Pattern.Core.hs              # PatternKind contract
+│   └── Pattern.RepresentationMap.hs # RepresentationMap + compose contract
+└── tasks.md             # Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+### Source Code
+
+```text
+libs/pattern/src/
+├── Pattern/
+│   ├── Core.hs                  # Add: PatternKind, checkKind, RankNTypes extension
+│   └── RepresentationMap.hs     # New: RepresentationMap, compose
+└── Pattern.hs                   # Add: re-export Pattern.RepresentationMap
+
+libs/pattern/
+└── pattern.cabal                # Add: Pattern.RepresentationMap to exposed-modules
+
+libs/pattern/tests/
+└── Spec/Pattern/
+    └── RepresentationMapSpec.hs # New: unit + property tests, diagnosticMap
+```
+
+**Structure Decision**: Single library project. Source additions are additive — no existing files are restructured. `Pattern.RepresentationMap` is a new peer module alongside `Pattern.Graph.*`.
+
+## Implementation Phases
+
+### Phase 1: `PatternKind` in `Pattern.Core`
+
+**Goal**: Named, scope-aware shape predicates.
+
+**Changes**:
+1. Add `{-# LANGUAGE RankNTypes #-}` to `Pattern/Core.hs`
+2. Add `PatternKind v` data type with `kindName`, `kindPred`, `kindExample`
+3. Add `checkKind` convenience function
+4. Add `PatternKind`, `checkKind` to `Pattern.Core` exports
+5. Add `PatternKind`, `checkKind` to `Pattern.hs` re-exports
+
+**Tests** (in `RepresentationMapSpec.hs`):
+- T001: `kindPred` returns true for canonical example (the invariant)
+- T002: `kindPred` returns false for a pattern not of that kind
+- T003: scope-relative predicate uses `allElements` correctly
+- T004: structural predicate ignores scope argument
+
+**Checkpoint commit**: `"representation-map: PatternKind in Pattern.Core"`
+
+---
+
+### Phase 2: `RepresentationMap` + `compose` in `Pattern.RepresentationMap`
+
+**Goal**: Named invertible isomorphisms between shape kinds.
+
+**Changes**:
+1. Create `libs/pattern/src/Pattern/RepresentationMap.hs`
+2. Implement `RepresentationMap v` data type
+3. Implement `compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)`
+4. Add `Pattern.RepresentationMap` to `exposed-modules` in `pattern.cabal`
+5. Add re-export to `Pattern.hs`
+
+**Tests**:
+- T005: `compose` with compatible kinds produces map from domain-of-first to codomain-of-second
+- T006: `compose` combined `name` uses " >>> " separator
+- T007: `compose` combined `conventions` is union of both
+- T008: `compose` returns `Left` when `kindName (codomain m1) /= kindName (domain m2)` — error message names both kinds
+- T009: composed `forward` applies m1 then m2
+- T010: composed `inverse` applies m2-inverse then m1-inverse
+
+**Checkpoint commit**: `"representation-map: RepresentationMap + compose"`
+
+---
+
+### Phase 3: `diagnosticMap` prototype and round-trip property tests
+
+**Goal**: Validate the abstraction with a concrete isomorphism; establish the round-trip property-test pattern.
+
+**Shape kinds**:
+- `DiagnosticPattern`: `Location` pattern directly containing a `Diagnostic` pattern, which directly contains zero or more `Remediation` patterns
+- `DiagnosticGraph`: flat atomic patterns with labels `Location`, `Diagnostic`, `Remediation` connected by `AT`/`HAS_REMEDIATION` relationship patterns; each non-relationship pattern has `_arity` (Int) and `_depth` (Int) properties
+
+**Conventions** (the structural decisions that make inversion possible):
+- `"_arity encodes element count of the corresponding nested pattern node"`
+- `"_depth encodes nesting depth, enabling reconstruction of order"`
+
+**Forward transform** (DiagnosticPattern → DiagnosticGraph):
+- Traverse the nested structure with `paraWithScope` and `TrivialScope`
+- Emit flat atomic patterns for each Location/Diagnostic/Remediation node
+- Annotate each with `_arity` (count of direct elements) and `_depth` (nesting depth)
+- Emit `AT` relationship patterns connecting Location→Diagnostic
+- Emit `HAS_REMEDIATION` relationship patterns connecting Diagnostic→Remediation
+
+**Inverse transform** (DiagnosticGraph → DiagnosticPattern):
+- Find all `Diagnostic` patterns via `allElements` on scope
+- Find their `Location` containers via `containers`
+- Find their `Remediation` children via `allElements` filtered by `HAS_REMEDIATION`
+- Reconstruct nesting order from `_depth` property
+- Emit nested `Pattern` structure
+
+**Tests**:
+- T011: `forward` applied to canonical `DiagnosticPattern` example satisfies `DiagnosticGraph` kind predicate
+- T012: `inverse` applied to canonical `DiagnosticGraph` example satisfies `DiagnosticPattern` kind predicate
+- T013: round-trip on canonical example: `(inverse . forward) canonicalDiagnostic == canonicalDiagnostic`
+- T014: QuickCheck property — `forAll` generated `DiagnosticPattern`s, `roundTrip` holds
+- T015: QuickCheck property — after `compose diagnosticMap identityMap`, round-trip still holds (composition preserves correctness)
+- T016: `diagnosticMap` conventions list is non-empty and contains `"_arity"` and `"_depth"`
+
+**Checkpoint commit**: `"representation-map: diagnosticMap prototype and round-trip tests"`
+
+---
+
+### Phase 4: Regression and full test suite
+
+**Goal**: Confirm zero regressions.
+
+**Actions**:
+- Run full `pattern-hs` test suite
+- Confirm all pre-existing tests pass without modification
+- No call-site changes required anywhere
+
+**Checkpoint commit**: `"representation-map: full test suite passing"` (only if any incidental fixes needed)
+
+---
+
+## Acceptance Criteria
+
+| Criterion | Verified By |
+|---|---|
+| `PatternKind` + `checkKind` exported from `Pattern.Core` | Module compilation + export check |
+| `RepresentationMap` + `compose` exported from `Pattern.RepresentationMap` | Module compilation + export check |
+| `kindPred (kindExample k)` is always true | T001 |
+| `compose` fails with descriptive error on mismatch | T008 |
+| `diagnosticMap` forward produces `DiagnosticGraph`-kind output | T011 |
+| `diagnosticMap` round-trip holds for all generated inputs | T014 (QuickCheck) |
+| Composition preserves round-trip | T015 |
+| All existing tests pass | Phase 4 full run |
+
+## Cross-Language Correspondence (for Rust port)
+
+| Haskell | Rust |
+|---|---|
+| `PatternKind v` | `struct PatternKind<V>` with `Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> bool>` |
+| `RepresentationMap v` | `struct RepresentationMap<V>` with `Box<dyn Fn(...)>` fields |
+| `forall q. ScopeQuery q v =>` | `&dyn ScopeQuery<V>` at trait-object boundary; `impl ScopeQuery<V>` for monomorphic paths |
+| `compose` → `Either String` | `Result<RepresentationMap<V>, String>` |
+| QuickCheck property test | `proptest` or `quickcheck` crate |
+
+Document in porting guide when Rust port is undertaken.

--- a/specs/039-representation-map/quickstart.md
+++ b/specs/039-representation-map/quickstart.md
@@ -1,0 +1,123 @@
+# Quick Reference: RepresentationMap (039)
+
+## New exports
+
+### `Pattern.Core`
+
+```haskell
+data PatternKind v = PatternKind
+  { kindName    :: String
+  , kindPred    :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+  , kindExample :: Pattern v
+  }
+
+checkKind :: ScopeQuery q v => PatternKind v -> q v -> Pattern v -> Bool
+```
+
+### `Pattern.RepresentationMap` (new module)
+
+```haskell
+data RepresentationMap v = RepresentationMap
+  { name        :: String
+  , domain      :: PatternKind v
+  , codomain    :: PatternKind v
+  , conventions :: [String]
+  , forward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , inverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , roundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+  }
+
+compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)
+```
+
+---
+
+## Define a shape kind
+
+```haskell
+{-# LANGUAGE RankNTypes #-}
+
+import Pattern.Core (PatternKind(..), Pattern(..), ScopeQuery)
+
+-- A pattern that has a specific label in its value
+hasLabel :: String -> Pattern Subject -> Bool
+hasLabel lbl p = lbl `Set.member` labels (value p)
+
+locationKind :: PatternKind Subject
+locationKind = PatternKind
+  { kindName    = "Location"
+  , kindPred    = \_ p -> hasLabel "Location" p
+  , kindExample = Pattern (subject "loc1" ["Location"] []) []
+  }
+```
+
+---
+
+## Define a representation map
+
+```haskell
+import Pattern.RepresentationMap (RepresentationMap(..))
+
+-- Nested → flat (forward) and flat → nested (inverse)
+myMap :: RepresentationMap Subject
+myMap = RepresentationMap
+  { name        = "LocationFlatMap"
+  , domain      = nestedLocationKind
+  , codomain    = flatLocationKind
+  , conventions = ["_depth encodes nesting level"]
+  , forward     = \q p -> flattenWith "_depth" q p
+  , inverse     = \q p -> nestFromDepth "_depth" q p
+  , roundTrip   = \q p ->
+      let result = (inverse myMap q . forward myMap q) p
+      in  result == p
+  }
+```
+
+---
+
+## Check kind membership
+
+```haskell
+import Pattern.Core (trivialScope, checkKind)
+
+let scope = trivialScope somePattern
+let isMember = checkKind locationKind scope somePattern
+-- True if somePattern has label "Location"
+```
+
+---
+
+## Compose maps
+
+```haskell
+import Pattern.RepresentationMap (compose)
+
+case compose mapAtoB mapBtoC of
+  Left err     -> putStrLn $ "Incompatible: " <> err
+  Right mapAtoC -> -- use the composed map
+    let result = forward mapAtoC (trivialScope p) p
+```
+
+---
+
+## Round-trip property test (QuickCheck)
+
+```haskell
+import Test.QuickCheck
+
+prop_roundTrip :: RepresentationMap Subject -> Property
+prop_roundTrip m =
+  forAll (arbitrary `suchThat` checkKind (domain m) trivScope) $ \p ->
+    let trivScope = trivialScope p
+    in  roundTrip m trivScope p
+  where trivScope p = trivialScope p  -- note: scope is per-pattern here
+```
+
+---
+
+## Implementation notes
+
+- `RankNTypes` is required for `forall q.` in record fields
+- `kindPred` is polymorphic: structural predicates ignore the scope argument; use `containers`/`allElements`/`byIdentity` for scope-relative checks
+- `roundTrip` implementation typically just checks `(inverse q . forward q) p == p`; requires `Eq v`
+- `compose` returns `Either String` — check the `Left` case when connecting maps from different domains

--- a/specs/039-representation-map/quickstart.md
+++ b/specs/039-representation-map/quickstart.md
@@ -18,12 +18,12 @@ checkKind :: ScopeQuery q v => PatternKind v -> q v -> Pattern v -> Bool
 
 ```haskell
 data RepresentationMap v = RepresentationMap
-  { name        :: String
-  , domain      :: PatternKind v
-  , codomain    :: PatternKind v
-  , forward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
-  , inverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
-  , roundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+  { repMapName        :: String
+  , repMapDomain      :: PatternKind v
+  , repMapCodomain    :: PatternKind v
+  , repMapForward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , repMapInverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , repMapRoundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
   }
 
 compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)
@@ -60,13 +60,13 @@ import Pattern.RepresentationMap (RepresentationMap(..))
 -- Nested → flat (forward) and flat → nested (inverse)
 myMap :: RepresentationMap Subject
 myMap = RepresentationMap
-  { name        = "LocationFlatMap"
-  , domain      = nestedLocationKind
-  , codomain    = flatLocationKind
-  , forward     = \q p -> flattenWith "_depth" q p
-  , inverse     = \q p -> nestFromDepth "_depth" q p
-  , roundTrip   = \q p ->
-      let result = (inverse myMap q . forward myMap q) p
+  { repMapName        = "LocationFlatMap"
+  , repMapDomain      = nestedLocationKind
+  , repMapCodomain    = flatLocationKind
+  , repMapForward     = \q p -> flattenWith "_depth" q p
+  , repMapInverse     = \q p -> nestFromDepth "_depth" q p
+  , repMapRoundTrip   = \q p ->
+      let result = (repMapInverse myMap q . repMapForward myMap q) p
       in  result == p
   }
 ```
@@ -93,7 +93,7 @@ import Pattern.RepresentationMap (compose)
 case compose mapAtoB mapBtoC of
   Left err     -> putStrLn $ "Incompatible: " <> err
   Right mapAtoC -> -- use the composed map
-    let result = forward mapAtoC (trivialScope p) p
+    let result = repMapForward mapAtoC (trivialScope p) p
 ```
 
 ---
@@ -107,7 +107,7 @@ prop_roundTrip :: RepresentationMap Subject -> Gen (Pattern Subject) -> Property
 prop_roundTrip m genDomainPattern =
   forAll genDomainPattern $ \p ->
     let scope = trivialScope p
-    in  checkKind (domain m) scope p && roundTrip m scope p
+    in  checkKind (repMapDomain m) scope p && repMapRoundTrip m scope p
 ```
 
 ---
@@ -116,6 +116,6 @@ prop_roundTrip m genDomainPattern =
 
 - `RankNTypes` is required for `forall q.` in record fields
 - `kindPred` is polymorphic: structural predicates ignore the scope argument; use `containers`/`allElements`/`byIdentity` for scope-relative checks
-- `roundTrip` implementation typically just checks `(inverse q . forward q) p == p`; requires `Eq v`
+- `repMapRoundTrip` implementation typically just checks `(repMapInverse q . repMapForward q) p == p`; requires `Eq v`
 - `compose` returns `Either String` — check the `Left` case when connecting maps from different domains
 - Documentation about encoding choices belongs next to the map definition for now; attaching inline prose to the map value itself is deferred until the project has a more declarative, checkable design for map claims

--- a/specs/039-representation-map/quickstart.md
+++ b/specs/039-representation-map/quickstart.md
@@ -21,7 +21,6 @@ data RepresentationMap v = RepresentationMap
   { name        :: String
   , domain      :: PatternKind v
   , codomain    :: PatternKind v
-  , conventions :: [String]
   , forward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
   , inverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
   , roundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
@@ -64,7 +63,6 @@ myMap = RepresentationMap
   { name        = "LocationFlatMap"
   , domain      = nestedLocationKind
   , codomain    = flatLocationKind
-  , conventions = ["_depth encodes nesting level"]
   , forward     = \q p -> flattenWith "_depth" q p
   , inverse     = \q p -> nestFromDepth "_depth" q p
   , roundTrip   = \q p ->
@@ -105,12 +103,11 @@ case compose mapAtoB mapBtoC of
 ```haskell
 import Test.QuickCheck
 
-prop_roundTrip :: RepresentationMap Subject -> Property
-prop_roundTrip m =
-  forAll (arbitrary `suchThat` checkKind (domain m) trivScope) $ \p ->
-    let trivScope = trivialScope p
-    in  roundTrip m trivScope p
-  where trivScope p = trivialScope p  -- note: scope is per-pattern here
+prop_roundTrip :: RepresentationMap Subject -> Gen (Pattern Subject) -> Property
+prop_roundTrip m genDomainPattern =
+  forAll genDomainPattern $ \p ->
+    let scope = trivialScope p
+    in  checkKind (domain m) scope p && roundTrip m scope p
 ```
 
 ---
@@ -121,3 +118,4 @@ prop_roundTrip m =
 - `kindPred` is polymorphic: structural predicates ignore the scope argument; use `containers`/`allElements`/`byIdentity` for scope-relative checks
 - `roundTrip` implementation typically just checks `(inverse q . forward q) p == p`; requires `Eq v`
 - `compose` returns `Either String` — check the `Left` case when connecting maps from different domains
+- Documentation about encoding choices belongs next to the map definition for now; attaching inline prose to the map value itself is deferred until the project has a more declarative, checkable design for map claims

--- a/specs/039-representation-map/research.md
+++ b/specs/039-representation-map/research.md
@@ -5,9 +5,9 @@
 
 ---
 
-## Decision 1: `Text` vs `String` for names and conventions
+## Decision 1: `Text` vs `String` for names
 
-**Decision**: Use `String` throughout (`kindName`, `name`, `conventions`).
+**Decision**: Use `String` throughout (`kindName`, `name`).
 
 **Rationale**: The project has no `text` package dependency in `pattern.cabal`. The `Subject` type uses `String` for labels and property keys. Introducing `Text` would add a new dependency for cosmetic benefit.
 
@@ -81,6 +81,14 @@
 **Decision**: Deferred. The current `scopeDictFromGraphView` (in `Pattern.Graph.Transform`) already provides a `ScopeDict (Id v) v` from a `GraphView`, which is sufficient for any transform needing graph-wide scope. Making `GraphQuery` directly implement `ScopeQuery` is a design improvement that belongs in a follow-on focused on the `GraphScope` gap.
 
 **Rationale**: Zero existing call sites need to change. The `diagnosticMap` uses `TrivialScope` or a graph-backed `ScopeDict`. No urgency.
+
+---
+
+## Decision 9: `RepresentationMap.conventions`
+
+**Decision**: Remove `conventions` from `RepresentationMap`.
+
+**Rationale**: In the current prototype, the field stores structured inline documentation rather than executable semantics. Concrete encoding choices such as `_arity` and `_depth` still matter, but they are better captured today in Haddocks, examples, and round-trip tests than as opaque text attached to the value. A future iteration may introduce declarative, machine-checkable claims once there is enough experience with multiple concrete maps to generalize responsibly.
 
 ---
 

--- a/specs/039-representation-map/research.md
+++ b/specs/039-representation-map/research.md
@@ -1,0 +1,110 @@
+# Research: RepresentationMap (039)
+
+**Date**: 2026-03-17
+**Branch**: `039-representation-map`
+
+---
+
+## Decision 1: `Text` vs `String` for names and conventions
+
+**Decision**: Use `String` throughout (`kindName`, `name`, `conventions`).
+
+**Rationale**: The project has no `text` package dependency in `pattern.cabal`. The `Subject` type uses `String` for labels and property keys. Introducing `Text` would add a new dependency for cosmetic benefit.
+
+**Alternatives considered**: `Text` (Data.Text) — idiomatic Haskell for text data, but not used anywhere in the current codebase. Add only when the project adopts it broadly.
+
+---
+
+## Decision 2: Property-based test framework
+
+**Decision**: Use QuickCheck (`Test.QuickCheck`) for property-based round-trip tests.
+
+**Rationale**: The project already depends on QuickCheck (`^>=2.14`) and has `Arbitrary` instances for `Pattern String`, `Pattern Int`, etc. in `tests/Spec/Pattern/Properties.hs`. The proposal mentions Hedgehog, but that is not a current dependency. QuickCheck's `forAll` and `quickCheck`/`property` provide equivalent round-trip testing capability.
+
+**Alternatives considered**: Hedgehog — shrinking behavior is superior, but requires adding a new dependency and learning a new API. Defer until the project decides to adopt it broadly.
+
+---
+
+## Decision 3: Module placement
+
+**Decision**:
+- `PatternKind` → `Pattern.Core` (alongside `ScopeQuery`, `para`, `paraWithScope`)
+- `RepresentationMap` + `compose` → new `Pattern.RepresentationMap` module
+- `diagnosticMap` → new `Pattern.RepresentationMap.Diagnostic` module (or inline in tests for the prototype)
+
+**Rationale**: `PatternKind` is a pure `Pattern v` concept — a predicate with a name and example. It belongs beside `ScopeQuery` in `Pattern.Core`. `RepresentationMap` pairs two `PatternKind`s with transforms; it is a higher-level abstraction that warrants its own module. The diagnostic map is a concrete domain-specific instance, not part of the core abstraction.
+
+**Alternatives considered**: All in `Pattern.Core` — would bloat the module significantly. All in a single `Pattern.RepresentationMap` — viable but mixes abstraction definition with concrete instances.
+
+---
+
+## Decision 4: `RankNTypes` for `forall q.` fields
+
+**Decision**: Add `{-# LANGUAGE RankNTypes #-}` to `Pattern.Core` and `Pattern.RepresentationMap`.
+
+**Rationale**: The `kindPred`, `forward`, `inverse`, and `roundTrip` fields in `PatternKind` and `RepresentationMap` are universally quantified over `q`: `forall q. ScopeQuery q v => q v -> ...`. This requires `RankNTypes`. The project already uses `TypeFamilies`, `MultiParamTypeClasses`, and `FlexibleInstances`; `RankNTypes` is a natural addition.
+
+**Alternatives considered**: Reify to `ScopeDict` at the point of storage — would lose polymorphism and require callers to pre-reify. Not acceptable; the whole point is scope-agnostic transforms.
+
+---
+
+## Decision 5: Kind compatibility check in `compose`
+
+**Decision**: Runtime check by comparing `kindName` strings. `compose m1 m2` fails if `kindName (codomain m1) /= kindName (domain m2)`.
+
+**Rationale**: Per the proposal's open question, phantom-type-level kind checking is deferred until the abstraction is stable. The runtime check is safe and surfaces mismatches immediately.
+
+**Alternatives considered**: Phantom type tags at the type level — would make mismatches compile-time errors but requires kinds to be named at the type level (complex GADT or type-tagged approach). Deferred.
+
+---
+
+## Decision 6: `diagnosticMap` placement
+
+**Decision**: Define `diagnosticKinds` and `diagnosticMap` inline in a dedicated test/example file for the prototype: `tests/Spec/Pattern/RepresentationMapSpec.hs`. They are not exported from the library in this feature.
+
+**Rationale**: The diagnostic map is a domain-specific instance of the abstraction, not part of the core library. Shipping it in the library would couple the library to a specific domain. For the prototype, test files are the right place: they validate the abstraction and serve as usage examples.
+
+**Alternatives considered**: Export from `Pattern.RepresentationMap.Diagnostic` — appropriate once the abstraction is stable and the team decides to ship example maps. Deferred to a follow-on.
+
+---
+
+## Decision 7: `GraphScope` typeclass
+
+**Decision**: Deferred. Not required for `PatternKind`, `RepresentationMap`, or `diagnosticMap`. The `diagnosticMap` forward and inverse transforms use only the generic `ScopeQuery` contract (`containers`, `allElements`, `byIdentity`). `GraphScope` (source/target/incidents) will be introduced when a concrete map requires graph-topology operations.
+
+**Rationale**: Per spec Assumption. Adding `GraphScope` now would be speculative scope expansion with no concrete use case in this feature.
+
+---
+
+## Decision 8: `ScopeQuery` instance for `GraphQuery`
+
+**Decision**: Deferred. The current `scopeDictFromGraphView` (in `Pattern.Graph.Transform`) already provides a `ScopeDict (Id v) v` from a `GraphView`, which is sufficient for any transform needing graph-wide scope. Making `GraphQuery` directly implement `ScopeQuery` is a design improvement that belongs in a follow-on focused on the `GraphScope` gap.
+
+**Rationale**: Zero existing call sites need to change. The `diagnosticMap` uses `TrivialScope` or a graph-backed `ScopeDict`. No urgency.
+
+---
+
+## Existing infrastructure confirmed available
+
+| Component | Location | Status |
+|---|---|---|
+| `ScopeQuery` typeclass | `Pattern/Core.hs:1175` | ✅ |
+| `TrivialScope` + `trivialScope` | `Pattern/Core.hs:1208` | ✅ |
+| `ScopeDict` + `toScopeDict` | `Pattern/Core.hs:1236` | ✅ |
+| `paraWithScope` | `Pattern/Core.hs:1293` | ✅ |
+| `para` | `Pattern/Core.hs:1350` | ✅ |
+| `scopeDictFromGraphView` | `Pattern/Graph/Transform.hs:245` | ✅ |
+| `GraphView` | `Pattern/Graph/Types.hs:40` | ✅ |
+| `Arbitrary Pattern` instances | `tests/Spec/Pattern/Properties.hs` | ✅ |
+| QuickCheck | cabal dependency | ✅ |
+| `Subject` (with labels, properties) | `libs/subject/src/Subject/Core.hs` | ✅ |
+
+---
+
+## Language extensions required
+
+New extensions needed:
+- `RankNTypes` — for `forall q. ScopeQuery q v => ...` in record fields
+
+Already present (no action needed):
+- `TypeFamilies`, `MultiParamTypeClasses`, `FlexibleInstances`, `InstanceSigs`

--- a/specs/039-representation-map/spec.md
+++ b/specs/039-representation-map/spec.md
@@ -28,7 +28,7 @@ This is the foundational concept: before you can map between two shape kinds, yo
 
 ### User Story 2 - Transform Patterns Between Shape Kinds (Priority: P2)
 
-A library developer declares a named `RepresentationMap` — an invertible mapping between a source kind and a target kind. They apply the forward transform to convert a source pattern into the target kind, and apply the inverse to convert back. The map records its name, the two kinds it connects, and the structural conventions that make the round-trip possible.
+A library developer declares a named `RepresentationMap` — an invertible mapping between a source kind and a target kind. They apply the forward transform to convert a source pattern into the target kind, and apply the inverse to convert back. The map records its name, the two kinds it connects, and a round-trip witness.
 
 **Why this priority**: The forward and inverse transforms are the core capability. Without them, declaring shape kinds has no practical consequence beyond validation. The map is the mechanism that makes two representations interchangeable.
 
@@ -38,8 +38,7 @@ A library developer declares a named `RepresentationMap` — an invertible mappi
 
 1. **Given** a `RepresentationMap` whose domain is `DiagnosticPattern` (nested location/diagnostic/remediation), **When** the forward transform is applied to a pattern satisfying `DiagnosticPattern`, **Then** the result satisfies the `DiagnosticGraph` kind predicate.
 2. **Given** a `RepresentationMap` and a pattern of the codomain kind, **When** the inverse transform is applied, **Then** the result satisfies the domain kind predicate.
-3. **Given** a `RepresentationMap` with declared conventions (e.g., `_arity` encodes element count), **When** the map is inspected, **Then** the conventions are accessible by name.
-4. **Given** a scope that contains cross-references needed by the transform, **When** the forward transform is applied with that scope, **Then** cross-references are resolved correctly within the transform.
+3. **Given** a scope that contains cross-references needed by the transform, **When** the forward transform is applied with that scope, **Then** cross-references are resolved correctly within the transform.
 
 ---
 
@@ -61,7 +60,7 @@ A library developer verifies that a `RepresentationMap` is a true isomorphism: a
 
 ### User Story 4 - Compose Compatible Maps (Priority: P4)
 
-A library developer composes two `RepresentationMap`s where the codomain of the first matches the domain of the second, producing a third map that connects the first domain to the second codomain. The composed map carries the union of both maps' conventions and preserves the round-trip property end-to-end.
+A library developer composes two `RepresentationMap`s where the codomain of the first matches the domain of the second, producing a third map that connects the first domain to the second codomain and preserves the round-trip property end-to-end.
 
 **Why this priority**: Composability is what makes the library extensible. Without it, every representation conversion requires a new hand-written map. With it, intermediate forms can be named and chained, and the space of recognized shapes is navigable step-by-step.
 
@@ -70,9 +69,8 @@ A library developer composes two `RepresentationMap`s where the codomain of the 
 **Acceptance Scenarios**:
 
 1. **Given** two maps `m1` (A → B) and `m2` (B → C), **When** they are composed, **Then** the result is a map from A to C whose forward applies `m1.forward` then `m2.forward`.
-2. **Given** a composed map, **When** the conventions are inspected, **Then** they include all conventions from both constituent maps.
-3. **Given** two maps where the codomain of `m1` does not match the domain of `m2`, **When** composition is attempted, **Then** the operation fails with a clear message identifying the mismatch.
-4. **Given** a composed map, **When** the round-trip predicate is applied to a domain-kind pattern, **Then** it holds (composition preserves the isomorphism).
+2. **Given** two maps where the codomain of `m1` does not match the domain of `m2`, **When** composition is attempted, **Then** the operation fails with a clear message identifying the mismatch.
+3. **Given** a composed map, **When** the round-trip predicate is applied to a domain-kind pattern, **Then** it holds (composition preserves the isomorphism).
 
 ---
 
@@ -81,8 +79,7 @@ A library developer composes two `RepresentationMap`s where the codomain of the 
 - What happens when a transform produces a pattern that does not satisfy the declared codomain kind? The map is incorrectly specified — this should be detectable by checking `kindPred (codomain map) q (forward q p)`.
 - What happens when the forward transform references elements by identity but the scope has duplicate identities? Duplicate identities within a scope are an error and should be rejected, not silently collapsed.
 - What happens when a pattern satisfies multiple shape kinds? Each kind is independent; a pattern may simultaneously satisfy many kinds. Kind membership is not exclusive.
-- What happens when conventions are absent from a map that requires them to invert? The round-trip property will fail, surfacing the missing convention as a test failure rather than a runtime error.
-- What happens when two maps' conventions conflict on composition? Conventions are concatenated, not validated for consistency. Conflict detection is out of scope for this feature.
+- What happens when a concrete map depends on encoding choices such as `_arity` or `_depth`? Those choices are documented alongside the map implementation and validated through kind checks and round-trip tests; a first-class declarative claims model is deferred.
 
 ---
 
@@ -93,21 +90,20 @@ A library developer composes two `RepresentationMap`s where the codomain of the 
 - **FR-001**: The library MUST provide a `PatternKind` abstraction: a named, scope-aware predicate that classifies patterns as belonging or not belonging to a named shape kind.
 - **FR-002**: A `PatternKind` MUST include a canonical example pattern that always satisfies its own predicate.
 - **FR-003**: The `PatternKind` predicate MUST be evaluable at any scope level — structural predicates (self-contained) and scope-relative predicates (cross-referencing) MUST use the same interface.
-- **FR-004**: The library MUST provide a `RepresentationMap` abstraction: a named record pairing a domain kind, a codomain kind, a set of named conventions, a forward transform, an inverse transform, and a round-trip predicate.
+- **FR-004**: The library MUST provide a `RepresentationMap` abstraction: a named record pairing a domain kind, a codomain kind, a forward transform, an inverse transform, and a round-trip predicate.
 - **FR-005**: The forward and inverse transforms in a `RepresentationMap` MUST be polymorphic over scope — they MUST operate correctly given any scope that satisfies the generic scope contract, not only a graph-backed scope.
 - **FR-006**: The library MUST provide a `compose` operation that takes two compatible `RepresentationMap`s (codomain of first = domain of second) and produces a third map connecting the first domain to the second codomain.
 - **FR-007**: `compose` MUST fail with a clear error when the codomain kind of the first map does not match the domain kind of the second.
-- **FR-008**: The composed map's conventions MUST be the union of both constituent maps' conventions.
-- **FR-009**: The round-trip predicate of the composed map MUST hold whenever the round-trip predicates of both constituent maps hold.
-- **FR-010**: The library MUST include a concrete `diagnosticMap` instance: a `RepresentationMap` between the nested `DiagnosticPattern` shape kind and the flat `DiagnosticGraph` shape kind, with at least two named conventions (`_arity` and `_depth` encoding).
-- **FR-011**: The `diagnosticMap` MUST pass a property-based round-trip test suite that generates arbitrary `DiagnosticPattern`-satisfying inputs and verifies the round-trip predicate for each.
-- **FR-012**: All existing operations that fold, map, or filter over patterns MUST continue to work without change after this feature is introduced.
+- **FR-008**: The round-trip predicate of the composed map MUST hold whenever the round-trip predicates of both constituent maps hold.
+- **FR-009**: The feature MUST include a concrete `diagnosticMap` test/example instance: a `RepresentationMap` between the nested `DiagnosticPattern` shape kind and the flat `DiagnosticGraph` shape kind, using `_arity` and `_depth` in its implementation and documentation.
+- **FR-010**: The `diagnosticMap` test/example MUST pass a property-based round-trip test suite that generates arbitrary `DiagnosticPattern`-satisfying inputs and verifies the round-trip predicate for each.
+- **FR-011**: All existing operations that fold, map, or filter over patterns MUST continue to work without change after this feature is introduced.
 
 ### Key Entities
 
 - **PatternKind**: A named, recognizable class of pattern shapes. Defined by a scope-aware predicate and a canonical example. Not an individual pattern — the description of a family of patterns.
-- **RepresentationMap**: A named, invertible, composable isomorphism between two `PatternKind`s. Carries the structural conventions that make invertibility possible, and a round-trip predicate as the machine-checkable isomorphism witness.
-- **Convention**: A named structural decision embedded in a `RepresentationMap` that the forward transform encodes into the codomain and the inverse relies on to reconstruct the domain. Examples: `_arity` (element count encoding), `_depth` (nesting depth encoding).
+- **RepresentationMap**: A named, invertible, composable isomorphism between two `PatternKind`s, with a round-trip predicate as the machine-checkable isomorphism witness.
+- **Encoding choice**: A concrete map-level decision such as `_arity` (element count encoding) or `_depth` (nesting depth encoding). These choices are currently documented beside the map implementation rather than stored on `RepresentationMap` values.
 - **Scope**: The containing context that defines what elements are visible during a transform. Provided by the caller; may be a subtree scope, a graph-backed scope, or any caller-defined scope satisfying the generic scope contract.
 
 ## Success Criteria *(mandatory)*
@@ -119,12 +115,12 @@ A library developer composes two `RepresentationMap`s where the codomain of the 
 - **SC-003**: The round-trip predicate holds for all generated `DiagnosticPattern`-kind inputs in the property-based test suite — zero failures across the full generated suite.
 - **SC-004**: A composed map's round-trip predicate passes for all domain-kind inputs that pass the round-trip predicates of both constituent maps — composition does not weaken correctness.
 - **SC-005**: All tests that passed before this feature is introduced continue to pass after it is introduced — zero regressions in existing fold, map, and filter operations.
-- **SC-006**: The `diagnosticMap` canonical example satisfies both `DiagnosticPattern` (before forward) and `DiagnosticGraph` (after forward), verifiable without property-based generation.
+- **SC-006**: The `diagnosticMap` test/example canonical input satisfies `DiagnosticPattern` before `forward`, and its mapped result satisfies `DiagnosticGraph`, verifiable without property-based generation.
 
 ## Assumptions
 
 - Kind compatibility in `compose` is checked by comparing kind names at runtime. Phantom-type-level kind checking is deferred until the abstraction is stable.
-- Conventions are represented as named text for this iteration. Machine-readable convention schemas are deferred to a follow-on proposal.
+- Inline `RepresentationMap` metadata for encoding conventions is deferred. Later work may introduce a declarative, machine-checkable claims model once there is more than one concrete map to generalize from.
 - `GraphScope` (graph-topology-specific scope operations: source, target, incidents) is deferred. The `diagnosticMap` and other initial maps require only the generic scope contract. `GraphScope` will be introduced when a concrete map requires graph topology.
 - The question of whether a `RepresentationMap` can itself be serialized as a `Pattern` is explicitly deferred until at least two concrete maps are implemented and their structure is well understood.
 - `pattern-equivalence` (syntactic equivalence within gram notation) is out of scope — it addresses a different concern than isomorphism between structurally distinct shape kinds.

--- a/specs/039-representation-map/spec.md
+++ b/specs/039-representation-map/spec.md
@@ -1,0 +1,130 @@
+# Feature Specification: RepresentationMap
+
+**Feature Branch**: `039-representation-map`
+**Created**: 2026-03-17
+**Status**: Draft
+**Input**: User description: "representation-map as described above and detailed in proposals/representation-map-proposal.md"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Recognize Named Shape Kinds (Priority: P1)
+
+A library developer defines a named shape kind — a description of what structural constraints a pattern must satisfy to be considered an instance of that kind. They then check whether any given pattern belongs to that kind, within a scope that provides context for cross-referencing.
+
+This is the foundational concept: before you can map between two shape kinds, you must be able to name them and recognize them.
+
+**Why this priority**: All other stories depend on `PatternKind` existing. Without the ability to name and recognize shape kinds, there is no domain or codomain for a `RepresentationMap`, and no way to verify that a transformation produces the expected output kind.
+
+**Independent Test**: Can be fully tested by defining two distinct shape kinds, generating example patterns, and asserting that kind membership predicates correctly classify patterns as belonging or not belonging to each kind. Delivers named, recognizable shape constraints usable for validation and property-test generation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `PatternKind` with a predicate that matches patterns having a `Location` label directly containing a `Diagnostic` label, **When** a pattern matching that structure is checked, **Then** the kind predicate returns true.
+2. **Given** a `PatternKind` with the above predicate, **When** a flat pattern with a `Diagnostic` label but no enclosing `Location` is checked, **Then** the kind predicate returns false.
+3. **Given** a `PatternKind` with a canonical example, **When** the example is checked against the kind predicate, **Then** the predicate returns true (the example is always a member of its own kind).
+4. **Given** a scope-relative predicate (e.g., "a pattern that is referenced by another element in scope"), **When** the predicate is evaluated with a scope that contains the referencing element, **Then** it returns true; when evaluated without that context, it returns false.
+
+---
+
+### User Story 2 - Transform Patterns Between Shape Kinds (Priority: P2)
+
+A library developer declares a named `RepresentationMap` — an invertible mapping between a source kind and a target kind. They apply the forward transform to convert a source pattern into the target kind, and apply the inverse to convert back. The map records its name, the two kinds it connects, and the structural conventions that make the round-trip possible.
+
+**Why this priority**: The forward and inverse transforms are the core capability. Without them, declaring shape kinds has no practical consequence beyond validation. The map is the mechanism that makes two representations interchangeable.
+
+**Independent Test**: Can be fully tested by defining a `RepresentationMap` between two concrete shape kinds (e.g., nested diagnostic structure → flat node-relationship form), applying the forward transform to a known pattern, and verifying that the result satisfies the codomain kind predicate. Delivers the ability to convert between two named structural forms.
+
+**Acceptance Scenarios**:
+
+1. **Given** a `RepresentationMap` whose domain is `DiagnosticPattern` (nested location/diagnostic/remediation), **When** the forward transform is applied to a pattern satisfying `DiagnosticPattern`, **Then** the result satisfies the `DiagnosticGraph` kind predicate.
+2. **Given** a `RepresentationMap` and a pattern of the codomain kind, **When** the inverse transform is applied, **Then** the result satisfies the domain kind predicate.
+3. **Given** a `RepresentationMap` with declared conventions (e.g., `_arity` encodes element count), **When** the map is inspected, **Then** the conventions are accessible by name.
+4. **Given** a scope that contains cross-references needed by the transform, **When** the forward transform is applied with that scope, **Then** cross-references are resolved correctly within the transform.
+
+---
+
+### User Story 3 - Verify Round-Trip Correctness (Priority: P3)
+
+A library developer verifies that a `RepresentationMap` is a true isomorphism: applying the forward transform followed by the inverse recovers the original pattern, for all patterns of the domain kind. This property is machine-checkable via property-based tests using generated examples.
+
+**Why this priority**: The round-trip property is the formal witness that the map is an isomorphism, not just a one-way transform. Without it, the map has no guarantee of information preservation. This is what distinguishes a `RepresentationMap` from an arbitrary conversion function.
+
+**Independent Test**: Can be fully tested by running the round-trip predicate against the canonical example and a suite of generated domain-kind patterns. Delivers machine-checked confidence that forward and inverse are each other's inverse.
+
+**Acceptance Scenarios**:
+
+1. **Given** any pattern `p` satisfying the domain kind predicate, **When** the inverse transform is applied to `forward(p)`, **Then** the result equals `p` structurally.
+2. **Given** a pattern that does not satisfy the domain kind predicate, **When** the round-trip predicate is applied, **Then** the result is undefined (the map makes no guarantees outside its domain).
+3. **Given** a `RepresentationMap` and a property-test generator producing domain-kind patterns, **When** the round-trip predicate is run over the generated suite, **Then** all cases pass.
+
+---
+
+### User Story 4 - Compose Compatible Maps (Priority: P4)
+
+A library developer composes two `RepresentationMap`s where the codomain of the first matches the domain of the second, producing a third map that connects the first domain to the second codomain. The composed map carries the union of both maps' conventions and preserves the round-trip property end-to-end.
+
+**Why this priority**: Composability is what makes the library extensible. Without it, every representation conversion requires a new hand-written map. With it, intermediate forms can be named and chained, and the space of recognized shapes is navigable step-by-step.
+
+**Independent Test**: Can be fully tested by composing two known maps and verifying that the composed map's round-trip predicate holds for patterns of the first map's domain kind. Delivers the ability to chain transformations without writing new maps from scratch.
+
+**Acceptance Scenarios**:
+
+1. **Given** two maps `m1` (A → B) and `m2` (B → C), **When** they are composed, **Then** the result is a map from A to C whose forward applies `m1.forward` then `m2.forward`.
+2. **Given** a composed map, **When** the conventions are inspected, **Then** they include all conventions from both constituent maps.
+3. **Given** two maps where the codomain of `m1` does not match the domain of `m2`, **When** composition is attempted, **Then** the operation fails with a clear message identifying the mismatch.
+4. **Given** a composed map, **When** the round-trip predicate is applied to a domain-kind pattern, **Then** it holds (composition preserves the isomorphism).
+
+---
+
+### Edge Cases
+
+- What happens when a transform produces a pattern that does not satisfy the declared codomain kind? The map is incorrectly specified — this should be detectable by checking `kindPred (codomain map) q (forward q p)`.
+- What happens when the forward transform references elements by identity but the scope has duplicate identities? Duplicate identities within a scope are an error and should be rejected, not silently collapsed.
+- What happens when a pattern satisfies multiple shape kinds? Each kind is independent; a pattern may simultaneously satisfy many kinds. Kind membership is not exclusive.
+- What happens when conventions are absent from a map that requires them to invert? The round-trip property will fail, surfacing the missing convention as a test failure rather than a runtime error.
+- What happens when two maps' conventions conflict on composition? Conventions are concatenated, not validated for consistency. Conflict detection is out of scope for this feature.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The library MUST provide a `PatternKind` abstraction: a named, scope-aware predicate that classifies patterns as belonging or not belonging to a named shape kind.
+- **FR-002**: A `PatternKind` MUST include a canonical example pattern that always satisfies its own predicate.
+- **FR-003**: The `PatternKind` predicate MUST be evaluable at any scope level — structural predicates (self-contained) and scope-relative predicates (cross-referencing) MUST use the same interface.
+- **FR-004**: The library MUST provide a `RepresentationMap` abstraction: a named record pairing a domain kind, a codomain kind, a set of named conventions, a forward transform, an inverse transform, and a round-trip predicate.
+- **FR-005**: The forward and inverse transforms in a `RepresentationMap` MUST be polymorphic over scope — they MUST operate correctly given any scope that satisfies the generic scope contract, not only a graph-backed scope.
+- **FR-006**: The library MUST provide a `compose` operation that takes two compatible `RepresentationMap`s (codomain of first = domain of second) and produces a third map connecting the first domain to the second codomain.
+- **FR-007**: `compose` MUST fail with a clear error when the codomain kind of the first map does not match the domain kind of the second.
+- **FR-008**: The composed map's conventions MUST be the union of both constituent maps' conventions.
+- **FR-009**: The round-trip predicate of the composed map MUST hold whenever the round-trip predicates of both constituent maps hold.
+- **FR-010**: The library MUST include a concrete `diagnosticMap` instance: a `RepresentationMap` between the nested `DiagnosticPattern` shape kind and the flat `DiagnosticGraph` shape kind, with at least two named conventions (`_arity` and `_depth` encoding).
+- **FR-011**: The `diagnosticMap` MUST pass a property-based round-trip test suite that generates arbitrary `DiagnosticPattern`-satisfying inputs and verifies the round-trip predicate for each.
+- **FR-012**: All existing operations that fold, map, or filter over patterns MUST continue to work without change after this feature is introduced.
+
+### Key Entities
+
+- **PatternKind**: A named, recognizable class of pattern shapes. Defined by a scope-aware predicate and a canonical example. Not an individual pattern — the description of a family of patterns.
+- **RepresentationMap**: A named, invertible, composable isomorphism between two `PatternKind`s. Carries the structural conventions that make invertibility possible, and a round-trip predicate as the machine-checkable isomorphism witness.
+- **Convention**: A named structural decision embedded in a `RepresentationMap` that the forward transform encodes into the codomain and the inverse relies on to reconstruct the domain. Examples: `_arity` (element count encoding), `_depth` (nesting depth encoding).
+- **Scope**: The containing context that defines what elements are visible during a transform. Provided by the caller; may be a subtree scope, a graph-backed scope, or any caller-defined scope satisfying the generic scope contract.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Any pattern that satisfies a `PatternKind` predicate is classified as that kind in zero additional steps — kind membership is a single predicate evaluation, not a multi-step process.
+- **SC-002**: Applying the forward transform to any domain-kind pattern produces a result that satisfies the codomain kind predicate, verifiable by passing `kindPred (codomain map) q (forward q p)`.
+- **SC-003**: The round-trip predicate holds for all generated `DiagnosticPattern`-kind inputs in the property-based test suite — zero failures across the full generated suite.
+- **SC-004**: A composed map's round-trip predicate passes for all domain-kind inputs that pass the round-trip predicates of both constituent maps — composition does not weaken correctness.
+- **SC-005**: All tests that passed before this feature is introduced continue to pass after it is introduced — zero regressions in existing fold, map, and filter operations.
+- **SC-006**: The `diagnosticMap` canonical example satisfies both `DiagnosticPattern` (before forward) and `DiagnosticGraph` (after forward), verifiable without property-based generation.
+
+## Assumptions
+
+- Kind compatibility in `compose` is checked by comparing kind names at runtime. Phantom-type-level kind checking is deferred until the abstraction is stable.
+- Conventions are represented as named text for this iteration. Machine-readable convention schemas are deferred to a follow-on proposal.
+- `GraphScope` (graph-topology-specific scope operations: source, target, incidents) is deferred. The `diagnosticMap` and other initial maps require only the generic scope contract. `GraphScope` will be introduced when a concrete map requires graph topology.
+- The question of whether a `RepresentationMap` can itself be serialized as a `Pattern` is explicitly deferred until at least two concrete maps are implemented and their structure is well understood.
+- `pattern-equivalence` (syntactic equivalence within gram notation) is out of scope — it addresses a different concern than isomorphism between structurally distinct shape kinds.

--- a/specs/039-representation-map/tasks.md
+++ b/specs/039-representation-map/tasks.md
@@ -18,11 +18,11 @@
 
 **Purpose**: Scaffold new module files and wire them into the build before any user story implementation begins.
 
-- [ ] T001 Add `{-# LANGUAGE RankNTypes #-}` to `libs/pattern/src/Pattern/Core.hs` (required for `forall q.` in PatternKind fields)
-- [ ] T002 Create `libs/pattern/src/Pattern/RepresentationMap.hs` with module declaration, imports, and empty export list (scaffold only — no types yet)
-- [ ] T003 Add `Pattern.RepresentationMap` to `exposed-modules` in `libs/pattern/pattern.cabal`
-- [ ] T004 Add `import Pattern.RepresentationMap` and re-export stub to `libs/pattern/src/Pattern.hs`
-- [ ] T005 Create `libs/pattern/tests/Spec/Pattern/RepresentationMapSpec.hs` with module declaration and empty HSpec `spec :: Spec` (confirms test runner wires up)
+- [X] T001 Add `{-# LANGUAGE RankNTypes #-}` to `libs/pattern/src/Pattern/Core.hs` (required for `forall q.` in PatternKind fields)
+- [X] T002 Create `libs/pattern/src/Pattern/RepresentationMap.hs` with module declaration, imports, and empty export list (scaffold only — no types yet)
+- [X] T003 Add `Pattern.RepresentationMap` to `exposed-modules` in `libs/pattern/pattern.cabal`
+- [X] T004 Add `import Pattern.RepresentationMap` and re-export stub to `libs/pattern/src/Pattern.hs`
+- [X] T005 Create `libs/pattern/tests/Spec/Pattern/RepresentationMapSpec.hs` with module declaration and empty HSpec `spec :: Spec` (confirms test runner wires up)
 
 **Checkpoint**: `cabal build` and `cabal test` pass with empty new files in place.
 
@@ -34,8 +34,8 @@
 
 **⚠️ CRITICAL**: US1–US4 implementation cannot begin until this phase is complete and building cleanly.
 
-- [ ] T006 In `Pattern/RepresentationMap.hs`, add import of `Pattern.Core` (Pattern, ScopeQuery, PatternKind placeholder) — confirms module graph is valid before adding types
-- [ ] T007 In `RepresentationMapSpec.hs`, add import of `Pattern.Core` (Pattern, trivialScope, TrivialScope) — confirms test file can reach existing infrastructure
+- [X] T006 In `Pattern/RepresentationMap.hs`, add import of `Pattern.Core` (Pattern, ScopeQuery, PatternKind placeholder) — confirms module graph is valid before adding types
+- [X] T007 In `RepresentationMapSpec.hs`, add import of `Pattern.Core` (Pattern, trivialScope, TrivialScope) — confirms test file can reach existing infrastructure
 
 **Checkpoint**: `cabal build` passes cleanly with new files importing from existing modules.
 
@@ -51,18 +51,18 @@
 
 > **Write these tests FIRST — they must FAIL before implementation begins**
 
-- [ ] T008 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-001 — `kindPred k (trivialScope (kindExample k)) (kindExample k)` is `True` for any `PatternKind` (canonical example satisfies its own kind)
-- [ ] T009 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-002 — `kindPred` returns `False` for a pattern that does not match the kind's structural constraint
-- [ ] T010 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-003 — a scope-relative predicate using `allElements` correctly identifies a pattern that is only visible through the scope
-- [ ] T011 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-004 — a structural predicate returns the same result regardless of the scope argument supplied
+- [X] T008 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-001 — `kindPred k (trivialScope (kindExample k)) (kindExample k)` is `True` for any `PatternKind` (canonical example satisfies its own kind)
+- [X] T009 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-002 — `kindPred` returns `False` for a pattern that does not match the kind's structural constraint
+- [X] T010 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-003 — a scope-relative predicate using `allElements` correctly identifies a pattern that is only visible through the scope
+- [X] T011 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-004 — a structural predicate returns the same result regardless of the scope argument supplied
 
 ### Implementation for User Story 1
 
-- [ ] T012 [US1] Add `PatternKind v` data type to `libs/pattern/src/Pattern/Core.hs` with fields `kindName :: String`, `kindPred :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool`, `kindExample :: Pattern v` — requires `RankNTypes` (added in T001)
-- [ ] T013 [US1] Add `checkKind :: ScopeQuery q v => PatternKind v -> q v -> Pattern v -> Bool` to `libs/pattern/src/Pattern/Core.hs` — convenience wrapper over `kindPred`
-- [ ] T014 [US1] Add `PatternKind(..)` and `checkKind` to the export list of `libs/pattern/src/Pattern/Core.hs`
-- [ ] T015 [US1] Add `PatternKind(..)` and `checkKind` to re-exports in `libs/pattern/src/Pattern.hs`
-- [ ] T016 [US1] Update `Pattern/RepresentationMap.hs` import of `Pattern.Core` to include `PatternKind`, `kindName` (needed by `compose`)
+- [X] T012 [US1] Add `PatternKind v` data type to `libs/pattern/src/Pattern/Core.hs` with fields `kindName :: String`, `kindPred :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool`, `kindExample :: Pattern v` — requires `RankNTypes` (added in T001)
+- [X] T013 [US1] Add `checkKind :: ScopeQuery q v => PatternKind v -> q v -> Pattern v -> Bool` to `libs/pattern/src/Pattern/Core.hs` — convenience wrapper over `kindPred`
+- [X] T014 [US1] Add `PatternKind(..)` and `checkKind` to the export list of `libs/pattern/src/Pattern/Core.hs`
+- [X] T015 [US1] Add `PatternKind(..)` and `checkKind` to re-exports in `libs/pattern/src/Pattern.hs`
+- [X] T016 [US1] Update `Pattern/RepresentationMap.hs` import of `Pattern.Core` to include `PatternKind`, `kindName` (needed by `compose`)
 
 **Checkpoint**: T008–T011 all pass. `PatternKind` is exported and usable from `Pattern.Core`. `cabal test` passes with no regressions.
 
@@ -80,36 +80,34 @@ US2 and US4 share this phase because `compose` is defined in the same new module
 
 **Independent Test (US2)**: Construct a minimal `RepresentationMap` between two `PatternKind`s with identity-like `forward`/`inverse`. Verify `forward q p` satisfies `kindPred (codomain m)` (T-US2-001).
 
-**Independent Test (US4)**: Compose two maps. Verify the combined `name`, `conventions`, and `forward` behaviour (T-US4-001). Verify `Left` on kind mismatch (T-US4-003).
+**Independent Test (US4)**: Compose two maps. Verify the combined `name` and `forward` behaviour (T-US4-001). Verify `Left` on kind mismatch (T-US4-003).
 
 ### Tests for User Story 2
 
 > **Write these tests FIRST — they must FAIL before implementation begins**
 
-- [ ] T017 [P] [US2] In `RepresentationMapSpec.hs`: write T-US2-001 — `kindPred (codomain m) q (forward m q p)` is `True` for a domain-kind pattern `p`
-- [ ] T018 [P] [US2] In `RepresentationMapSpec.hs`: write T-US2-002 — `kindPred (domain m) q (inverse m q p)` is `True` for a codomain-kind pattern `p`
-- [ ] T019 [P] [US2] In `RepresentationMapSpec.hs`: write T-US2-003 — `conventions m` is accessible and matches declared list
+- [X] T017 [P] [US2] In `RepresentationMapSpec.hs`: write T-US2-001 — `kindPred (codomain m) q (forward m q p)` is `True` for a domain-kind pattern `p`
+- [X] T018 [P] [US2] In `RepresentationMapSpec.hs`: write T-US2-002 — `kindPred (domain m) q (inverse m q p)` is `True` for a codomain-kind pattern `p`
 
 ### Tests for User Story 4
 
-- [ ] T020 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-001 — `compose m1 m2` with compatible kinds returns `Right`; combined `name` contains " >>> "
-- [ ] T021 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-002 — composed `conventions` equals `conventions m1 <> conventions m2`
-- [ ] T022 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-003 — `compose m1 m2` returns `Left` when `kindName (codomain m1) /= kindName (domain m2)`; error message contains both kind names
-- [ ] T023 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-004 — composed `forward` applies `m1.forward` then `m2.forward`; composed `inverse` applies `m2.inverse` then `m1.inverse`
+- [X] T020 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-001 — `compose m1 m2` with compatible kinds returns `Right`; combined `name` contains " >>> "
+- [X] T022 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-003 — `compose m1 m2` returns `Left` when `kindName (codomain m1) /= kindName (domain m2)`; error message contains both kind names
+- [X] T023 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-004 — composed `forward` applies `m1.forward` then `m2.forward`; composed `inverse` applies `m2.inverse` then `m1.inverse`
 
 ### Implementation for User Story 2
 
-- [ ] T024 [US2] Add `RepresentationMap v` data type to `libs/pattern/src/Pattern/RepresentationMap.hs` with all seven fields (`name`, `domain`, `codomain`, `conventions`, `forward`, `inverse`, `roundTrip`) — add `{-# LANGUAGE RankNTypes #-}` pragma to this module
-- [ ] T025 [US2] Add `RepresentationMap(..)` to the export list of `libs/pattern/src/Pattern/RepresentationMap.hs`
-- [ ] T026 [US2] Add `RepresentationMap(..)` to re-exports in `libs/pattern/src/Pattern.hs`
+- [X] T024 [US2] Add `RepresentationMap v` data type to `libs/pattern/src/Pattern/RepresentationMap.hs` with fields `name`, `domain`, `codomain`, `forward`, `inverse`, `roundTrip` — add `{-# LANGUAGE RankNTypes #-}` pragma to this module
+- [X] T025 [US2] Add `RepresentationMap(..)` to the export list of `libs/pattern/src/Pattern/RepresentationMap.hs`
+- [X] T026 [US2] Add `RepresentationMap(..)` to re-exports in `libs/pattern/src/Pattern.hs`
 
 ### Implementation for User Story 4
 
-- [ ] T027 [US4] Implement `compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)` in `libs/pattern/src/Pattern/RepresentationMap.hs` — runtime kind-compat check via `kindName`; combined name/conventions/forward/inverse/roundTrip as specified in contract
-- [ ] T028 [US4] Add `compose` to the export list of `libs/pattern/src/Pattern/RepresentationMap.hs`
-- [ ] T029 [US4] Add `compose` to re-exports in `libs/pattern/src/Pattern.hs`
+- [X] T027 [US4] Implement `compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)` in `libs/pattern/src/Pattern/RepresentationMap.hs` — runtime kind-compat check via `kindName`; combined name/forward/inverse/roundTrip as specified in contract
+- [X] T028 [US4] Add `compose` to the export list of `libs/pattern/src/Pattern/RepresentationMap.hs`
+- [X] T029 [US4] Add `compose` to re-exports in `libs/pattern/src/Pattern.hs`
 
-**Checkpoint**: T017–T023 all pass. `RepresentationMap` and `compose` are exported. `cabal test` passes with no regressions.
+**Checkpoint**: The User Story 2 and User Story 4 tests all pass. `RepresentationMap` and `compose` are exported. `cabal test` passes with no regressions.
 
 **Commit**: `"representation-map: RepresentationMap + compose"`
 
@@ -123,26 +121,25 @@ US2 and US4 share this phase because `compose` is defined in the same new module
 
 ### Tests for User Story 3 (unit + property — write tests first, then forward, then inverse)
 
-- [ ] T030 [US3] In `RepresentationMapSpec.hs`: define `diagnosticPatternKind :: PatternKind Subject` — predicate checks for `"Location"` label containing a `"Diagnostic"` label; canonical example is a minimal nested pattern
-- [ ] T031 [US3] In `RepresentationMapSpec.hs`: define `diagnosticGraphKind :: PatternKind Subject` — predicate checks for flat atomic patterns with `"Location"`/`"Diagnostic"`/`"Remediation"` labels plus `_arity` and `_depth` properties
-- [ ] T032 [US3] In `RepresentationMapSpec.hs`: write T-US3-001 — `checkKind diagnosticGraphKind q (forward diagnosticMap q canonicalDiagnosticPattern)` is `True`
-- [ ] T033 [US3] In `RepresentationMapSpec.hs`: write T-US3-002 — `checkKind diagnosticPatternKind q (inverse diagnosticMap q canonicalDiagnosticGraph)` is `True`
-- [ ] T034 [US3] In `RepresentationMapSpec.hs`: write T-US3-003 — `(inverse diagnosticMap q . forward diagnosticMap q) canonicalDiagnosticPattern == canonicalDiagnosticPattern` (round-trip on canonical example)
+- [X] T030 [US3] In `RepresentationMapSpec.hs`: define `diagnosticPatternKind :: PatternKind Subject` — predicate checks for `"Location"` label containing a `"Diagnostic"` label; canonical example is a minimal nested pattern
+- [X] T031 [US3] In `RepresentationMapSpec.hs`: define `diagnosticGraphKind :: PatternKind Subject` — predicate checks for flat atomic patterns with `"Location"`/`"Diagnostic"`/`"Remediation"` labels plus `_arity` and `_depth` properties
+- [X] T032 [US3] In `RepresentationMapSpec.hs`: write T-US3-001 — `checkKind diagnosticGraphKind q (forward diagnosticMap q canonicalDiagnosticPattern)` is `True`
+- [X] T033 [US3] In `RepresentationMapSpec.hs`: write T-US3-002 — `checkKind diagnosticPatternKind q (inverse diagnosticMap q canonicalDiagnosticGraph)` is `True`
+- [X] T034 [US3] In `RepresentationMapSpec.hs`: write T-US3-003 — `(inverse diagnosticMap q . forward diagnosticMap q) canonicalDiagnosticPattern == canonicalDiagnosticPattern` (round-trip on canonical example)
 
 ### Implementation for User Story 3
 
-- [ ] T035 [US3] In `RepresentationMapSpec.hs`: implement `diagnosticForward :: ScopeQuery q Subject => q Subject -> Pattern Subject -> Pattern Subject` — traverse nested structure with `paraWithScope`; emit flat atomic patterns with `_arity`/`_depth` properties; emit `AT` and `HAS_REMEDIATION` relationship patterns
-- [ ] T036 [US3] In `RepresentationMapSpec.hs`: implement `diagnosticInverse :: ScopeQuery q Subject => q Subject -> Pattern Subject -> Pattern Subject` — use `allElements` and `containers` on scope to find Diagnostic/Location/Remediation patterns; reconstruct nesting order from `_depth`; emit nested `Pattern` structure
-- [ ] T037 [US3] In `RepresentationMapSpec.hs`: assemble `diagnosticMap :: RepresentationMap Subject` using `diagnosticPatternKind`, `diagnosticGraphKind`, `diagnosticForward`, `diagnosticInverse`, and an inline `roundTrip` check; conventions: `["_arity encodes element count", "_depth encodes nesting depth"]`
+- [X] T035 [US3] In `RepresentationMapSpec.hs`: implement `diagnosticForward :: ScopeQuery q Subject => q Subject -> Pattern Subject -> Pattern Subject` — traverse nested structure with `paraWithScope`; emit flat atomic patterns with `_arity`/`_depth` properties; emit `AT` and `HAS_REMEDIATION` relationship patterns
+- [X] T036 [US3] In `RepresentationMapSpec.hs`: implement `diagnosticInverse :: ScopeQuery q Subject => q Subject -> Pattern Subject -> Pattern Subject` — use `allElements` and `containers` on scope to find Diagnostic/Location/Remediation patterns; preserve the graph's existing remediation encounter order while stripping graph metadata; emit nested `Pattern` structure
+- [X] T037 [US3] In `RepresentationMapSpec.hs`: assemble `diagnosticMap :: RepresentationMap Subject` using `diagnosticPatternKind`, `diagnosticGraphKind`, `diagnosticForward`, `diagnosticInverse`, and an inline `roundTrip` check; document `_arity` and `_depth` beside the implementation
 
 ### Property tests for User Story 3
 
-- [ ] T038 [US3] In `RepresentationMapSpec.hs`: add `Arbitrary` instance or generator for `DiagnosticPattern`-satisfying `Pattern Subject` values (Location containing Diagnostic containing N Remediations, N ∈ [0..3])
-- [ ] T039 [US3] In `RepresentationMapSpec.hs`: write QuickCheck property `prop_diagnosticRoundTrip` — `forAll` generated DiagnosticPattern inputs, `roundTrip diagnosticMap (trivialScope p) p` holds; use `property` from `Test.QuickCheck`
-- [ ] T040 [US3] In `RepresentationMapSpec.hs`: write T-US3-004 — `diagnosticMap` conventions list contains `"_arity"` and `"_depth"` substrings
-- [ ] T041 [US3] In `RepresentationMapSpec.hs`: write composition smoke test — `compose diagnosticMap identityLikeMap` returns `Right`; composed round-trip holds for canonical example (covers SC-004)
+- [X] T038 [US3] In `RepresentationMapSpec.hs`: add `Arbitrary` instance or generator for `DiagnosticPattern`-satisfying `Pattern Subject` values (Location containing Diagnostic containing N Remediations, N ∈ [0..3])
+- [X] T039 [US3] In `RepresentationMapSpec.hs`: write QuickCheck property `prop_diagnosticRoundTrip` — `forAll` generated DiagnosticPattern inputs, `roundTrip diagnosticMap (trivialScope p) p` holds; use `property` from `Test.QuickCheck`
+- [X] T041 [US3] In `RepresentationMapSpec.hs`: write composition smoke test — `compose diagnosticMap identityLikeMap` returns `Right`; composed round-trip holds for canonical example (covers SC-004)
 
-**Checkpoint**: All T030–T041 pass. QuickCheck `prop_diagnosticRoundTrip` reports 100 tests passed. `cabal test` passes with no regressions.
+**Checkpoint**: The User Story 3 unit and property tests all pass. QuickCheck `prop_diagnosticRoundTrip` reports 100 tests passed. `cabal test` passes with no regressions.
 
 **Commit**: `"representation-map: diagnosticMap prototype and round-trip tests"`
 
@@ -152,10 +149,11 @@ US2 and US4 share this phase because `compose` is defined in the same new module
 
 **Purpose**: Regression validation, documentation completeness, and export hygiene.
 
-- [ ] T042 [P] Run full `pattern-hs` test suite (`cabal test`); confirm zero regressions — all pre-existing tests pass without modification
-- [ ] T043 [P] Add Haddock documentation to `PatternKind` fields in `libs/pattern/src/Pattern/Core.hs` — include categorical interpretation (subobject classifier) and invariant (`kindPred q (kindExample k) == True`)
-- [ ] T044 [P] Add Haddock documentation to `RepresentationMap` fields and `compose` in `libs/pattern/src/Pattern/RepresentationMap.hs` — include categorical interpretation (named isomorphism, morphism composition), invariants, and cross-language correspondence table (Haskell→Rust)
-- [ ] T045 Verify `Pattern.hs` re-exports: `PatternKind`, `checkKind`, `RepresentationMap`, `compose` are all reachable from a single `import Pattern` — write a one-line smoke test confirming import in `RepresentationMapSpec.hs`
+- [X] T042 [P] Run full `pattern-hs` test suite (`cabal test`); confirm zero regressions — all pre-existing tests pass without modification
+- [X] T043 [P] Add Haddock documentation to `PatternKind` fields in `libs/pattern/src/Pattern/Core.hs` — include categorical interpretation (subobject classifier) and invariant (`kindPred q (kindExample k) == True`)
+- [X] T044 [P] Add Haddock documentation to `RepresentationMap` fields and `compose` in `libs/pattern/src/Pattern/RepresentationMap.hs` — include categorical interpretation (named isomorphism, morphism composition), invariants, and note that declarative map claims are deferred
+- [X] T045 Verify `Pattern.hs` re-exports: `PatternKind`, `checkKind`, `RepresentationMap`, `compose` are all reachable from a single `import Pattern` — write a one-line smoke test confirming import in `RepresentationMapSpec.hs`
+- [X] T046 [P] Record the decision in `specs/039-representation-map/`: `RepresentationMap.conventions` is removed; concrete encoding choices remain documented beside implementations until a declarative, verifiable claims model exists
 
 **Commit**: `"representation-map: documentation and export verification"`
 

--- a/specs/039-representation-map/tasks.md
+++ b/specs/039-representation-map/tasks.md
@@ -1,0 +1,241 @@
+# Tasks: RepresentationMap
+
+**Input**: Design documents from `specs/039-representation-map/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+**Tests**: Included — spec and plan explicitly require unit tests for each phase and QuickCheck property tests for round-trip correctness (US3).
+
+**Organization**: Tasks are grouped by user story. US2 (Transform) and US4 (Compose) share a phase because `compose` lives in the same new module as `RepresentationMap`. US3 (Round-trip) is separated because it includes the concrete `diagnosticMap` and property-based tests.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Scaffold new module files and wire them into the build before any user story implementation begins.
+
+- [ ] T001 Add `{-# LANGUAGE RankNTypes #-}` to `libs/pattern/src/Pattern/Core.hs` (required for `forall q.` in PatternKind fields)
+- [ ] T002 Create `libs/pattern/src/Pattern/RepresentationMap.hs` with module declaration, imports, and empty export list (scaffold only — no types yet)
+- [ ] T003 Add `Pattern.RepresentationMap` to `exposed-modules` in `libs/pattern/pattern.cabal`
+- [ ] T004 Add `import Pattern.RepresentationMap` and re-export stub to `libs/pattern/src/Pattern.hs`
+- [ ] T005 Create `libs/pattern/tests/Spec/Pattern/RepresentationMapSpec.hs` with module declaration and empty HSpec `spec :: Spec` (confirms test runner wires up)
+
+**Checkpoint**: `cabal build` and `cabal test` pass with empty new files in place.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisite)
+
+**Purpose**: Confirm existing infrastructure is importable from the new module. This phase is minimal because the foundation (ScopeQuery, TrivialScope, ScopeDict, Pattern) already exists.
+
+**⚠️ CRITICAL**: US1–US4 implementation cannot begin until this phase is complete and building cleanly.
+
+- [ ] T006 In `Pattern/RepresentationMap.hs`, add import of `Pattern.Core` (Pattern, ScopeQuery, PatternKind placeholder) — confirms module graph is valid before adding types
+- [ ] T007 In `RepresentationMapSpec.hs`, add import of `Pattern.Core` (Pattern, trivialScope, TrivialScope) — confirms test file can reach existing infrastructure
+
+**Checkpoint**: `cabal build` passes cleanly with new files importing from existing modules.
+
+---
+
+## Phase 3: User Story 1 — Recognize Named Shape Kinds (P1) 🎯 MVP
+
+**Goal**: `PatternKind v` exists in `Pattern.Core` with a scope-aware membership predicate, a kind name, and a canonical example. Callers can define shape kinds and check pattern membership.
+
+**Independent Test**: Define two distinct `PatternKind` values with structural predicates. Verify the canonical example satisfies its own predicate (T-US1-001). Verify a non-matching pattern fails (T-US1-002). No other stories or new modules required.
+
+### Tests for User Story 1
+
+> **Write these tests FIRST — they must FAIL before implementation begins**
+
+- [ ] T008 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-001 — `kindPred k (trivialScope (kindExample k)) (kindExample k)` is `True` for any `PatternKind` (canonical example satisfies its own kind)
+- [ ] T009 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-002 — `kindPred` returns `False` for a pattern that does not match the kind's structural constraint
+- [ ] T010 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-003 — a scope-relative predicate using `allElements` correctly identifies a pattern that is only visible through the scope
+- [ ] T011 [P] [US1] In `RepresentationMapSpec.hs`: write T-US1-004 — a structural predicate returns the same result regardless of the scope argument supplied
+
+### Implementation for User Story 1
+
+- [ ] T012 [US1] Add `PatternKind v` data type to `libs/pattern/src/Pattern/Core.hs` with fields `kindName :: String`, `kindPred :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool`, `kindExample :: Pattern v` — requires `RankNTypes` (added in T001)
+- [ ] T013 [US1] Add `checkKind :: ScopeQuery q v => PatternKind v -> q v -> Pattern v -> Bool` to `libs/pattern/src/Pattern/Core.hs` — convenience wrapper over `kindPred`
+- [ ] T014 [US1] Add `PatternKind(..)` and `checkKind` to the export list of `libs/pattern/src/Pattern/Core.hs`
+- [ ] T015 [US1] Add `PatternKind(..)` and `checkKind` to re-exports in `libs/pattern/src/Pattern.hs`
+- [ ] T016 [US1] Update `Pattern/RepresentationMap.hs` import of `Pattern.Core` to include `PatternKind`, `kindName` (needed by `compose`)
+
+**Checkpoint**: T008–T011 all pass. `PatternKind` is exported and usable from `Pattern.Core`. `cabal test` passes with no regressions.
+
+**Commit**: `"representation-map: PatternKind in Pattern.Core"`
+
+---
+
+## Phase 4: User Story 2 + User Story 4 — Transform and Compose (P2 + P4)
+
+**Goal (US2)**: `RepresentationMap v` exists in `Pattern.RepresentationMap` with `forward`, `inverse`, and `roundTrip` fields. A map can be constructed over any two shape kinds.
+
+**Goal (US4)**: `compose` combines two compatible maps into a third. Incompatible kinds produce a `Left` error with a descriptive message.
+
+US2 and US4 share this phase because `compose` is defined in the same new module as `RepresentationMap` and has no independent testability from it.
+
+**Independent Test (US2)**: Construct a minimal `RepresentationMap` between two `PatternKind`s with identity-like `forward`/`inverse`. Verify `forward q p` satisfies `kindPred (codomain m)` (T-US2-001).
+
+**Independent Test (US4)**: Compose two maps. Verify the combined `name`, `conventions`, and `forward` behaviour (T-US4-001). Verify `Left` on kind mismatch (T-US4-003).
+
+### Tests for User Story 2
+
+> **Write these tests FIRST — they must FAIL before implementation begins**
+
+- [ ] T017 [P] [US2] In `RepresentationMapSpec.hs`: write T-US2-001 — `kindPred (codomain m) q (forward m q p)` is `True` for a domain-kind pattern `p`
+- [ ] T018 [P] [US2] In `RepresentationMapSpec.hs`: write T-US2-002 — `kindPred (domain m) q (inverse m q p)` is `True` for a codomain-kind pattern `p`
+- [ ] T019 [P] [US2] In `RepresentationMapSpec.hs`: write T-US2-003 — `conventions m` is accessible and matches declared list
+
+### Tests for User Story 4
+
+- [ ] T020 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-001 — `compose m1 m2` with compatible kinds returns `Right`; combined `name` contains " >>> "
+- [ ] T021 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-002 — composed `conventions` equals `conventions m1 <> conventions m2`
+- [ ] T022 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-003 — `compose m1 m2` returns `Left` when `kindName (codomain m1) /= kindName (domain m2)`; error message contains both kind names
+- [ ] T023 [P] [US4] In `RepresentationMapSpec.hs`: write T-US4-004 — composed `forward` applies `m1.forward` then `m2.forward`; composed `inverse` applies `m2.inverse` then `m1.inverse`
+
+### Implementation for User Story 2
+
+- [ ] T024 [US2] Add `RepresentationMap v` data type to `libs/pattern/src/Pattern/RepresentationMap.hs` with all seven fields (`name`, `domain`, `codomain`, `conventions`, `forward`, `inverse`, `roundTrip`) — add `{-# LANGUAGE RankNTypes #-}` pragma to this module
+- [ ] T025 [US2] Add `RepresentationMap(..)` to the export list of `libs/pattern/src/Pattern/RepresentationMap.hs`
+- [ ] T026 [US2] Add `RepresentationMap(..)` to re-exports in `libs/pattern/src/Pattern.hs`
+
+### Implementation for User Story 4
+
+- [ ] T027 [US4] Implement `compose :: RepresentationMap v -> RepresentationMap v -> Either String (RepresentationMap v)` in `libs/pattern/src/Pattern/RepresentationMap.hs` — runtime kind-compat check via `kindName`; combined name/conventions/forward/inverse/roundTrip as specified in contract
+- [ ] T028 [US4] Add `compose` to the export list of `libs/pattern/src/Pattern/RepresentationMap.hs`
+- [ ] T029 [US4] Add `compose` to re-exports in `libs/pattern/src/Pattern.hs`
+
+**Checkpoint**: T017–T023 all pass. `RepresentationMap` and `compose` are exported. `cabal test` passes with no regressions.
+
+**Commit**: `"representation-map: RepresentationMap + compose"`
+
+---
+
+## Phase 5: User Story 3 — Verify Round-Trip Correctness (P3)
+
+**Goal**: A concrete `diagnosticMap` (DiagnosticPattern ↔ DiagnosticGraph) demonstrates that the abstraction works end-to-end. QuickCheck property tests verify the round-trip for all generated inputs. The canonical example passes both kind predicates. This phase lives entirely in the test file — no library code changes.
+
+**Independent Test**: Run `cabal test` and confirm the QuickCheck property `prop_diagnosticRoundTrip` passes over 100+ generated inputs. Confirm T-US3-001 (canonical forward → DiagnosticGraph) and T-US3-002 (canonical inverse → DiagnosticPattern) pass as unit tests.
+
+### Tests for User Story 3 (unit + property — write tests first, then forward, then inverse)
+
+- [ ] T030 [US3] In `RepresentationMapSpec.hs`: define `diagnosticPatternKind :: PatternKind Subject` — predicate checks for `"Location"` label containing a `"Diagnostic"` label; canonical example is a minimal nested pattern
+- [ ] T031 [US3] In `RepresentationMapSpec.hs`: define `diagnosticGraphKind :: PatternKind Subject` — predicate checks for flat atomic patterns with `"Location"`/`"Diagnostic"`/`"Remediation"` labels plus `_arity` and `_depth` properties
+- [ ] T032 [US3] In `RepresentationMapSpec.hs`: write T-US3-001 — `checkKind diagnosticGraphKind q (forward diagnosticMap q canonicalDiagnosticPattern)` is `True`
+- [ ] T033 [US3] In `RepresentationMapSpec.hs`: write T-US3-002 — `checkKind diagnosticPatternKind q (inverse diagnosticMap q canonicalDiagnosticGraph)` is `True`
+- [ ] T034 [US3] In `RepresentationMapSpec.hs`: write T-US3-003 — `(inverse diagnosticMap q . forward diagnosticMap q) canonicalDiagnosticPattern == canonicalDiagnosticPattern` (round-trip on canonical example)
+
+### Implementation for User Story 3
+
+- [ ] T035 [US3] In `RepresentationMapSpec.hs`: implement `diagnosticForward :: ScopeQuery q Subject => q Subject -> Pattern Subject -> Pattern Subject` — traverse nested structure with `paraWithScope`; emit flat atomic patterns with `_arity`/`_depth` properties; emit `AT` and `HAS_REMEDIATION` relationship patterns
+- [ ] T036 [US3] In `RepresentationMapSpec.hs`: implement `diagnosticInverse :: ScopeQuery q Subject => q Subject -> Pattern Subject -> Pattern Subject` — use `allElements` and `containers` on scope to find Diagnostic/Location/Remediation patterns; reconstruct nesting order from `_depth`; emit nested `Pattern` structure
+- [ ] T037 [US3] In `RepresentationMapSpec.hs`: assemble `diagnosticMap :: RepresentationMap Subject` using `diagnosticPatternKind`, `diagnosticGraphKind`, `diagnosticForward`, `diagnosticInverse`, and an inline `roundTrip` check; conventions: `["_arity encodes element count", "_depth encodes nesting depth"]`
+
+### Property tests for User Story 3
+
+- [ ] T038 [US3] In `RepresentationMapSpec.hs`: add `Arbitrary` instance or generator for `DiagnosticPattern`-satisfying `Pattern Subject` values (Location containing Diagnostic containing N Remediations, N ∈ [0..3])
+- [ ] T039 [US3] In `RepresentationMapSpec.hs`: write QuickCheck property `prop_diagnosticRoundTrip` — `forAll` generated DiagnosticPattern inputs, `roundTrip diagnosticMap (trivialScope p) p` holds; use `property` from `Test.QuickCheck`
+- [ ] T040 [US3] In `RepresentationMapSpec.hs`: write T-US3-004 — `diagnosticMap` conventions list contains `"_arity"` and `"_depth"` substrings
+- [ ] T041 [US3] In `RepresentationMapSpec.hs`: write composition smoke test — `compose diagnosticMap identityLikeMap` returns `Right`; composed round-trip holds for canonical example (covers SC-004)
+
+**Checkpoint**: All T030–T041 pass. QuickCheck `prop_diagnosticRoundTrip` reports 100 tests passed. `cabal test` passes with no regressions.
+
+**Commit**: `"representation-map: diagnosticMap prototype and round-trip tests"`
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Regression validation, documentation completeness, and export hygiene.
+
+- [ ] T042 [P] Run full `pattern-hs` test suite (`cabal test`); confirm zero regressions — all pre-existing tests pass without modification
+- [ ] T043 [P] Add Haddock documentation to `PatternKind` fields in `libs/pattern/src/Pattern/Core.hs` — include categorical interpretation (subobject classifier) and invariant (`kindPred q (kindExample k) == True`)
+- [ ] T044 [P] Add Haddock documentation to `RepresentationMap` fields and `compose` in `libs/pattern/src/Pattern/RepresentationMap.hs` — include categorical interpretation (named isomorphism, morphism composition), invariants, and cross-language correspondence table (Haskell→Rust)
+- [ ] T045 Verify `Pattern.hs` re-exports: `PatternKind`, `checkKind`, `RepresentationMap`, `compose` are all reachable from a single `import Pattern` — write a one-line smoke test confirming import in `RepresentationMapSpec.hs`
+
+**Commit**: `"representation-map: documentation and export verification"`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 — blocks all user story phases
+- **Phase 3 (US1 PatternKind)**: Depends on Phase 2 — independently completable
+- **Phase 4 (US2+US4 RepresentationMap+compose)**: Depends on Phase 3 (needs `PatternKind` and `kindName`)
+- **Phase 5 (US3 Round-trip)**: Depends on Phase 4 (needs `RepresentationMap` and `compose`)
+- **Phase 6 (Polish)**: Depends on Phase 5
+
+### User Story Dependencies
+
+- **US1 (P1)**: Unblocked after Phase 2. No dependency on other user stories.
+- **US2 (P2)**: Depends on US1 — `RepresentationMap.domain` and `RepresentationMap.codomain` are `PatternKind` values.
+- **US4 (P4)**: Depends on US2 — `compose` operates on `RepresentationMap` values.
+- **US3 (P3)**: Depends on US2 + US4 — `diagnosticMap` uses `RepresentationMap`; composition smoke test uses `compose`.
+
+### Within Each Phase
+
+- Tests written and confirmed failing BEFORE implementation tasks begin
+- Module-level tasks (T001–T007) must complete before type/function tasks
+- Export tasks (T014, T028, T029) run after implementation tasks in same phase
+- `cabal build` passes at each checkpoint before commit
+
+### Parallel Opportunities
+
+- T008–T011 (US1 tests) can all be written in parallel — they are independent assertions in the same file
+- T017–T023 (US2+US4 tests) can all be written in parallel
+- T030–T034 (US3 unit tests) can be written in parallel with T035–T036 (forward/inverse impl) once test scaffolding (T030–T031) is in place
+- T042–T044 (Polish) can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Write all US1 tests in parallel (same file, no ordering between them):
+Task: "T008 — T-US1-001: canonical example satisfies own predicate"
+Task: "T009 — T-US1-002: non-matching pattern fails predicate"
+Task: "T010 — T-US1-003: scope-relative predicate uses allElements"
+Task: "T011 — T-US1-004: structural predicate ignores scope argument"
+
+# Then implement in sequence:
+Task: "T012 — PatternKind type definition"
+Task: "T013 — checkKind function"
+Task: "T014, T015 — exports"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001–T005)
+2. Complete Phase 2: Foundational (T006–T007)
+3. Complete Phase 3: US1 — PatternKind (T008–T016)
+4. **STOP and VALIDATE**: `cabal test` passes; `PatternKind` usable from `import Pattern`
+5. Shape kinds are now definable and checkable — independently useful for validation
+
+### Incremental Delivery
+
+1. Phase 1+2 → Build scaffolding clean
+2. Phase 3 (US1) → `PatternKind` usable → checkpoint commit
+3. Phase 4 (US2+US4) → `RepresentationMap` + `compose` usable → checkpoint commit
+4. Phase 5 (US3) → `diagnosticMap` + QuickCheck property tests passing → checkpoint commit
+5. Phase 6 → Full suite passing, docs complete → merge-ready
+
+---
+
+## Notes
+
+- All `forall q.` fields in `PatternKind` and `RepresentationMap` require `{-# LANGUAGE RankNTypes #-}` — added to `Pattern/Core.hs` in T001 and to `Pattern/RepresentationMap.hs` in T024
+- `compose` uses `kindName` string equality for kind-compat check — phantom type safety is deferred
+- The `diagnosticMap` lives in the test file for this prototype; it is not exported from the library
+- QuickCheck `suchThat` may produce slow generation if domain kind is complex — keep the `Arbitrary` generator (T038) direct rather than filtering
+- Each checkpoint commit keeps the branch bisectable


### PR DESCRIPTION
This pull request introduces the new "RepresentationMap" feature to the Pattern library, enabling named, invertible, composable mappings between different kinds of pattern shapes. It adds the concept of "pattern kinds" (named subtypes of patterns) and provides a framework for defining and composing isomorphisms between them. The changes include new modules, API extensions, and corresponding test scaffolding, all without introducing new dependencies.

**Core library enhancements:**

- Added the `PatternKind` type and `checkKind` function to `Pattern.Core`, allowing for named, scope-aware classification of pattern families. This enables predicates and runtime compatibility checks for pattern kinds. [[1]](diffhunk://#diff-aecd84bbd962967500f9ddb3f624fa9fc3f940654b7fe74fcfb284b1a23dcce9R1) [[2]](diffhunk://#diff-aecd84bbd962967500f9ddb3f624fa9fc3f940654b7fe74fcfb284b1a23dcce9R36-R38) [[3]](diffhunk://#diff-aecd84bbd962967500f9ddb3f624fa9fc3f940654b7fe74fcfb284b1a23dcce9R1194-R1225) [[4]](diffhunk://#diff-cfbf32dd4e729809b7d4b8ee6050f1e6fc33e63d4dd76c4c650d4022bd792856R1-R50)
- Introduced the new module `Pattern.RepresentationMap`, which defines the `RepresentationMap` type for invertible mappings between pattern kinds, and provides the `compose` function for safe composition of compatible maps. [[1]](diffhunk://#diff-ebe41064ed985ff18a87fafd4e1faeba54892ab795ca021da73e9b5c16074ceeR26) [[2]](diffhunk://#diff-160111770122c0ca13923296666ffeb19573710cbce0b7ddcd835dc0fc5b66b3R73-R74) [[3]](diffhunk://#diff-160111770122c0ca13923296666ffeb19573710cbce0b7ddcd835dc0fc5b66b3R94) [[4]](diffhunk://#diff-d296cbea1a282b4a3922e4c5fc5909b92be2589894d542c086548464c94e9a66R1-R79) [[5]](diffhunk://#diff-a0330b0f9677c059246fb180dc74bb0e976d2334dba76046fe27d4bd8d7fa901R1-R84)

**Testing and documentation:**

- Added `Spec.Pattern.RepresentationMapSpec` to the test suite and integrated it into the test runner, ensuring that RepresentationMap functionality is covered by property and unit tests. [[1]](diffhunk://#diff-ebe41064ed985ff18a87fafd4e1faeba54892ab795ca021da73e9b5c16074ceeR63) [[2]](diffhunk://#diff-135acd44f7b30c9eeb06b8e04ee16f2b4734542b9a9ce1fc6c4108ff959bbb3fR14) [[3]](diffhunk://#diff-135acd44f7b30c9eeb06b8e04ee16f2b4734542b9a9ce1fc6c4108ff959bbb3fR33)
- Updated documentation and feature tracking files (`CLAUDE.md`, specification checklists, and contracts) to reflect the new feature, its requirements, and API contracts. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R8-R9) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R29) [[3]](diffhunk://#diff-b884d70bc8e83ced9c0c08f014bce582b55be0f1fb935ab7c8b6bf3ffd330d6dR1-R39) [[4]](diffhunk://#diff-a0330b0f9677c059246fb180dc74bb0e976d2334dba76046fe27d4bd8d7fa901R1-R84)

**Project configuration:**

- Enabled tests for the `pattern` package in `cabal.project` and ensured no new dependencies were introduced for this feature.

These changes lay the groundwork for future development of declarative, machine-checkable representation maps and enable richer pattern shape transformations within the Pattern library.