### PR TITLE
Restructure design docs into numbered RFCs (RFC-002 through RFC-010)

### DIFF
--- a/proposals/design/DESIGN.md
+++ b/proposals/design/DESIGN.md
@@ -1,5 +1,11 @@
 # Patterns as Graph Views: A Categorical Framework
 
+> **Superseded by [RFC-002: Pattern as Container and Graph Substrate](RFC-002-pattern-container-substrate.md)**
+> 
+> This document is retained for historical reference. RFC-002 consolidates the content
+> here with `pattern-category.md`, removes stale "⏳ Planned" markers, and reorganises
+> into the standard RFC format.
+
 **Status**: ✅ Implemented  
 **Implementation**: Core Pattern type and typeclass instances are implemented. Graph Lens (Feature 23) is implemented. Some planned features (Zipper, Pattern Morphisms) are deferred.
 

--- a/proposals/design/EXTENDED-SEMANTICS.md
+++ b/proposals/design/EXTENDED-SEMANTICS.md
@@ -1,5 +1,10 @@
 # Gram Extended Semantics: Pattern and Path Notation
 
+> **Superseded by [RFC-003: Gram Notation Semantics](RFC-003-gram-notation-semantics.md)**
+> 
+> This document is retained for historical reference. RFC-003 merges this document with
+> `SEMANTICS.md` into a single authoritative reference for gram notation semantics.
+
 **Status**: ✅ Implemented  
 **Implementation**: Gram serialization and parsing support both pattern and path notation  
 **Reference**: See `docs/reference/semantics/gram-semantics.md` for current specification

--- a/proposals/design/README.md
+++ b/proposals/design/README.md
@@ -1,0 +1,86 @@
+# Design RFCs — pattern-hs
+
+This directory contains the authoritative design documents for pattern-hs, organized
+as numbered RFCs. Each RFC follows a standard format: Status, Summary, Motivation,
+Design, Open Questions, Alternatives.
+
+## RFC Index
+
+### Foundation (Accepted — Implemented)
+
+| RFC | Title | Status | Key Modules |
+|-----|-------|--------|-------------|
+| [RFC-001](RFC-001-strata-and-aspects.md) | Strata and Aspects | draft | `Pattern.Stratum`, `Pattern.Aspect` |
+| [RFC-002](RFC-002-pattern-container-substrate.md) | Pattern as Container and Graph Substrate | accepted | `Pattern.Core`, `Pattern.Graph.GraphLens` |
+| [RFC-003](RFC-003-gram-notation-semantics.md) | Gram Notation Semantics | accepted | `Gram.Core`, `Gram.Parser` |
+
+### Graph Interface Layer (Draft — Design)
+
+| RFC | Title | Status | Depends on |
+|-----|-------|--------|------------|
+| [RFC-004](RFC-004-graph-classifier.md) | GraphClassifier — Unified Graph View | draft | — |
+| [RFC-005](RFC-005-graph-query.md) | GraphQuery — Portable Query Interface | draft | RFC-004 |
+| [RFC-006](RFC-006-scope-unification.md) | Scope Unification — ScopeQuery and paraWithScope | draft | RFC-005 |
+| [RFC-007](RFC-007-representation-map.md) | RepresentationMap — Invertible Shape Isomorphisms | draft | RFC-006, RFC-008 |
+| [RFC-008](RFC-008-graph-transform.md) | GraphTransform — Construction, Transformation, Pipeline | draft | RFC-004, RFC-005 |
+| [RFC-009](RFC-009-graph-mutation.md) | GraphMutation — Coherent In-Memory Graph Mutations | draft | RFC-004, RFC-005, RFC-008 |
+| [RFC-010](RFC-010-pattern-reconciliation.md) | Pattern Reconciliation | draft | — |
+
+## Implementation Order
+
+The graph interface RFCs form a dependency chain:
+
+```
+RFC-004 (GraphClassifier)
+  └── RFC-005 (GraphQuery)
+        ├── RFC-006 (ScopeQuery)  ──→  RFC-007 (RepresentationMap)
+        ├── RFC-008 (GraphTransform)
+        │     └── RFC-009 (GraphMutation)
+        └── RFC-010 (Pattern Reconciliation) [independent]
+```
+
+RFC-007 (RepresentationMap) additionally depends on RFC-008 (GraphTransform) being
+settled first, since it builds on `paraWithScope` and the GraphTransform primitives.
+
+## Superseded Documents
+
+The following documents in this directory have been superseded by RFCs and are retained
+for historical reference only:
+
+| File | Superseded by |
+|------|---------------|
+| [DESIGN.md](DESIGN.md) | RFC-002 |
+| [SEMANTICS.md](SEMANTICS.md) | RFC-003 |
+| [EXTENDED-SEMANTICS.md](EXTENDED-SEMANTICS.md) | RFC-003 |
+| [pattern-category.md](pattern-category.md) | RFC-002 |
+
+The following documents in `proposals/` (parent directory) are similarly superseded:
+
+| File | Superseded by |
+|------|---------------|
+| `proposals/graph-classifier.md` | RFC-004 |
+| `proposals/graph-query.md` | RFC-005 |
+| `proposals/scope-unification-proposal.md` | RFC-006 |
+| `proposals/representation-map-proposal.md` | RFC-006 + RFC-007 |
+| `proposals/graph-transform.md` | RFC-008 |
+| `proposals/pipeline-scenarios.md` | RFC-008 |
+| `proposals/graph-mutation.md` | RFC-009 |
+| `proposals/pattern-reconciliation.md` | RFC-010 |
+
+## Non-RFC Documents
+
+The following documents in this directory serve specific purposes and are not RFCs:
+
+| File | Purpose |
+|------|---------|
+| [pattern-basic-aspects-review.md](pattern-basic-aspects-review.md) | Implementation reference: `length`, `size`, `depth` query functions |
+| [graph-lens.md](graph-lens.md) | Implementation notes for the `GraphLens` feature |
+| [gram-hs-cli-improvements.md](gram-hs-cli-improvements.md) | CLI tool improvement proposals |
+| [gram-hs-cli-plan.md](gram-hs-cli-plan.md) | CLI tool implementation plan |
+| [pattern-matching-dsl-design.md](pattern-matching-dsl-design.md) | Pattern matching DSL exploration |
+
+The following document in `proposals/` is a pre-RFC stub pending full design:
+
+| File | Status |
+|------|--------|
+| `proposals/pattern-equivalence.md` | Pre-RFC: motivating examples only; needs full design |

--- a/proposals/design/README.md
+++ b/proposals/design/README.md
@@ -10,9 +10,15 @@ Design, Open Questions, Alternatives.
 
 | RFC | Title | Status | Key Modules |
 |-----|-------|--------|-------------|
-| [RFC-001](RFC-001-strata-and-aspects.md) | Strata and Aspects | draft | `Pattern.Stratum`, `Pattern.Aspect` |
 | [RFC-002](RFC-002-pattern-container-substrate.md) | Pattern as Container and Graph Substrate | accepted | `Pattern.Core`, `Pattern.Graph.GraphLens` |
 | [RFC-003](RFC-003-gram-notation-semantics.md) | Gram Notation Semantics | accepted | `Gram.Core`, `Gram.Parser` |
+| [RFC-010](RFC-010-pattern-reconciliation.md) | Pattern Reconciliation | accepted | `Pattern.Reconcile`, `Subject.Core` |
+
+### Active Design (Draft — In Progress)
+
+| RFC | Title | Status | Key Modules |
+|-----|-------|--------|-------------|
+| [RFC-001](RFC-001-strata-and-aspects.md) | Strata and Aspects | draft | `Pattern.Stratum`, `Pattern.Aspect` |
 
 ### Graph Interface Layer (Draft — Design)
 
@@ -24,7 +30,6 @@ Design, Open Questions, Alternatives.
 | [RFC-007](RFC-007-representation-map.md) | RepresentationMap — Invertible Shape Isomorphisms | draft | RFC-006, RFC-008 |
 | [RFC-008](RFC-008-graph-transform.md) | GraphTransform — Construction, Transformation, Pipeline | draft | RFC-004, RFC-005 |
 | [RFC-009](RFC-009-graph-mutation.md) | GraphMutation — Coherent In-Memory Graph Mutations | draft | RFC-004, RFC-005, RFC-008 |
-| [RFC-010](RFC-010-pattern-reconciliation.md) | Pattern Reconciliation | draft | — |
 
 ## Implementation Order
 
@@ -34,13 +39,15 @@ The graph interface RFCs form a dependency chain:
 RFC-004 (GraphClassifier)
   └── RFC-005 (GraphQuery)
         ├── RFC-006 (ScopeQuery)  ──→  RFC-007 (RepresentationMap)
-        ├── RFC-008 (GraphTransform)
-        │     └── RFC-009 (GraphMutation)
-        └── RFC-010 (Pattern Reconciliation) [independent]
+        └── RFC-008 (GraphTransform)
+              └── RFC-009 (GraphMutation)
 ```
 
 RFC-007 (RepresentationMap) additionally depends on RFC-008 (GraphTransform) being
 settled first, since it builds on `paraWithScope` and the GraphTransform primitives.
+
+RFC-010 (Pattern Reconciliation) is accepted and implemented independently of the
+graph interface chain.
 
 ## Superseded Documents
 

--- a/proposals/design/RFC-002-pattern-container-substrate.md
+++ b/proposals/design/RFC-002-pattern-container-substrate.md
@@ -1,0 +1,268 @@
+# RFC-002: Pattern as Container and Graph Substrate
+
+**Status:** accepted
+**Date:** 2025-11-01
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/design/DESIGN.md`](DESIGN.md), [`proposals/design/pattern-category.md`](pattern-category.md)
+**Related modules:** `Pattern.Core`, `Pattern.Graph.GraphLens`, `Pattern.PatternGraph`
+
+## Summary
+
+`Pattern v` is a recursive decorated-sequence container: a value paired with an ordered
+list of element Patterns. It is not itself a graph; graph structure is an *interpretation*
+imposed by external machinery. The same `Pattern v` can be interpreted as a directed graph,
+an undirected graph, a walk, or any other graph-like structure depending on which view is
+applied. This separation of container from interpretation is the load-bearing design choice
+that enables flexibility across graph semantics without committing to any single one.
+
+## Motivation
+
+Graph data structures traditionally encode semantic commitments in their types: a
+`DiGraph` is directed, an `UndirectedGraph` is not, a `WeightedGraph` carries edge
+weights. This forces users to choose an interpretation at construction time and makes
+multiple simultaneous interpretations cumbersome.
+
+`Pattern v` inverts this: a universal container accumulates structure, and views impose
+interpretations on demand. The same Pattern that represents a person's professional
+network can simultaneously represent their social graph, their org chart, or a sequence
+of career transitions — without duplicating data. The interpretation that is salient
+depends on the question being asked, not on how the data was originally stored.
+
+This is the motivation for separating substrate from interpretation.
+
+## Design
+
+### The Pattern Data Structure
+
+```haskell
+data Pattern v = Pattern
+  { value    :: v           -- decoration: what kind of pattern this is
+  , elements :: [Pattern v] -- the pattern's content, as an ordered sequence
+  }
+```
+
+Patterns are recursive: every element of a Pattern is itself a Pattern. The `elements`
+field is the sequence that defines the pattern's content; the `value` field is a
+decoration that describes what the sequence means.
+
+**Key insight**: The elements field IS the pattern — it contains the sequence that defines
+the content. The value field decorates that content. For example, a pattern `[chord | C, E, G]`
+has value `chord` decorating the sequence `[C, E, G]`.
+
+### Conceptual Model: Decorated Sequences
+
+Conceptually, patterns are **decorated sequences**:
+- `elements` holds the sequence that defines the pattern
+- `value` provides decoration about what kind of pattern it is
+- Order of elements is semantically significant — patterns are ordered
+- Recursive structure enables nested sequences (patterns containing patterns)
+
+The tree structure is an implementation detail that supports sequences in memory. There
+is no contradiction between these views — the tree structure is how sequences are
+represented, and tree traversal preserves sequence order.
+
+### Structural Classifications
+
+Patterns have structural classifications based on element count. These describe what
+patterns *are* structurally, independent of any interpretation.
+
+**Atomic Pattern** — `elements == []`. The fundamental building block; the leaf of any
+Pattern tree. Nodes in the graph interpretation are atomic patterns.
+
+**Singular Pattern** — exactly one element. A pattern wrapping a single sub-pattern.
+
+**Pattern with Elements** — one or more elements. The general case.
+
+**Nested Pattern** — elements that themselves have elements, enabling arbitrary depth.
+
+### Graph Interpretations
+
+Patterns are *interpreted* as graph elements through views. The same structural
+classification rules apply across all interpretations.
+
+#### Nodes
+
+A node is an atomic pattern — a Pattern with no elements.
+
+```haskell
+node :: v -> Pattern v
+node v = Pattern v []
+```
+
+Notation equivalences:
+```
+Cypher:  (n:Person)
+Pattern: [n:Person]
+```
+
+#### Relationships
+
+**Undirected**: a pattern with exactly two atomic elements; order is semantically irrelevant.
+**Directed**: a pattern with exactly two atomic elements, where element order encodes direction —
+`element[0]` is the source, `element[1]` is the target.
+
+```haskell
+-- Source/target accessors
+source :: Pattern v -> Pattern v
+source (Pattern _ (s:_)) = s
+
+target :: Pattern v -> Pattern v
+target (Pattern _ [_, t]) = t
+
+-- Reverse direction
+reverseRel :: Pattern v -> Pattern v
+reverseRel (Pattern v [a, b]) = Pattern v [b, a]
+```
+
+Notation equivalences:
+```
+Cypher:  (a)-[r:KNOWS]->(b)    Pattern: [r:KNOWS | a, b]  -- directed, a→b
+Cypher:  (a)<-[r:KNOWS]-(b)   Pattern: [r:KNOWS | b, a]  -- directed, b→a
+Cypher:  (a)-[r:KNOWS]-(b)    Pattern: [r:KNOWS | a, b]  -- undirected (order irrelevant)
+```
+
+**Design rationale**: direction is encoded positionally in the existing ordered-sequence
+structure, with no extra type machinery. Reversing a relationship is a structural
+operation: swap the two elements. Directed vs. undirected is a semantic distinction
+managed by the consumer, not a structural one.
+
+#### Walks
+
+A walk is an ordered sequence of relationships allowing continuous traversal: entering
+each relationship at one endpoint and exiting at the other, which becomes the entry
+point of the next relationship.
+
+```haskell
+walk :: v -> [Pattern v] -> Pattern v
+walk meta relationships = Pattern meta relationships
+```
+
+```
+Cypher: (a)-[r1]->(b)<-[r2]-(c)-[r3]->(d)
+Pattern: [walk | [r1 | a, b], [r2 | c, b], [r3 | c, d]]
+```
+
+Valid walk compositions in Pattern notation:
+```
+[w | [r1 | a, b]]              =~ (a)-[r1]->(b)
+[w | [r1 | a, b], [r2 | c, b]] =~ (a)-[r1]->(b)<-[r2]-(c)
+[w | [r1 | a, b], [r2 | b, a]] =~ (a)-[r1]->(b)-[r2]->(a)
+```
+
+#### Summary
+
+| Concept        | Pattern Structure            | Convention                          |
+|----------------|------------------------------|-------------------------------------|
+| Node           | `[v]`                        | Atomic pattern (no elements)        |
+| Undirected Rel | `[r \| (a), (b)]`            | Order semantically irrelevant       |
+| Directed Rel   | `[r \| (a), (b)]`            | element[0]=source, element[1]=target |
+| Walk           | `[meta \| rel1, rel2, ...]`  | Consecutive rels share endpoints    |
+
+### Typeclass Instances
+
+`Pattern v` is implemented with the following typeclass instances (all accepted):
+
+- `Functor` — structure-preserving map over values: `fmap f` transforms every `v` while
+  preserving the Pattern tree structure
+- `Foldable` — fold over all values in traversal order
+- `Traversable` — effectful traversal, combining Functor and Foldable
+- `Applicative` — zip-like application of a Pattern of functions to a Pattern of values
+- `Comonad` — `extract` retrieves the root value; `extend` maps with local context;
+  `duplicate` produces the Pattern of all sub-Patterns
+- `Eq`, `Ord`, `Hashable` — structural equality, ordering, and hashing
+- `Semigroup`, `Monoid` — Pattern combination with identity
+- `Show`, `ToJSON`, `FromJSON` — display and serialization
+
+### Category-Theoretic Perspective
+
+`Pattern v` admits a categorical interpretation through a `CategoryLens`, which defines
+what counts as objects and how values compose:
+
+```haskell
+data CategoryLens v = CategoryLens
+  { valueOp :: v -> v -> v      -- value composition (magma operation)
+  , isObject :: Pattern v -> Bool  -- which patterns are objects
+  }
+```
+
+Under a graph lens, leaf patterns (atoms) are objects and arity-2 patterns are morphisms.
+Objects and morphisms are identified *post-hoc* through predicates, not enforced at
+construction time.
+
+**Composition** preserves structure rather than flattening:
+
+```haskell
+compose :: (v -> v -> v) -> Pattern v -> Pattern v -> Pattern v
+compose f (Pattern v1 elems1) (Pattern v2 elems2) =
+  Pattern (f v1 v2) [Pattern v1 elems1, Pattern v2 elems2]
+```
+
+The original patterns become elements of the composite, maintaining internal structure.
+
+**Morphism equivalence** — two patterns are equivalent as morphisms when they have the
+same leaf sequence (same objects in sequence order). Three levels:
+
+- *Structural equivalence*: same complete leaf sequence
+- *Endpoint equivalence*: same source and target objects (hom-set membership)
+- *Custom*: domain-specific equivalence relation
+
+**The category is not intrinsic to `Pattern`**; it emerges from the chosen lens. The
+same `Pattern v` can support many different categorical structures by varying the lens,
+validity rules, or equivalence relation. This is the "schema-lazy" property: maximum
+flexibility during construction, multiple valid interpretations on demand.
+
+### Forgetful Functor Hierarchy
+
+Views form a hierarchy of forgetful functors, each losing information as it descends:
+
+```
+Pat[Full] --F₁--> Pat[Shape] --F₂--> Pat[Topology] --F₃--> Pat[Connected]
+```
+
+```haskell
+forgetValues :: Pattern v -> Pattern ()
+forgetValues = fmap (const ())
+```
+
+This enables analogical reasoning: match patterns that are structurally similar under
+some forgetting, even if their values differ.
+
+### Key Properties
+
+1. **Schema-lazy** — Patterns do not commit to specific graph semantics; interpretation
+   happens in the view. The same Pattern is valid under any compatible view.
+2. **Compositional** — Views can be composed, stacked, or swapped without changing
+   underlying patterns.
+3. **Open-ended** — New views can be defined for any graph-like interpretation.
+4. **Categorical** — Each view defines a functor; forgetful matching uses functor
+   composition.
+
+## Open Questions
+
+1. **Navigation functions** — `source`, `target`, `nodes`, `relationships` as explicit
+   Pattern operations are planned but not implemented. They would provide ergonomic
+   access to graph-structured patterns without requiring a full view.
+
+2. **Zipper for focus** — A `Zipper v` data structure supporting `parents` /
+   `ancestors` operations would enable DOM-style upward navigation and focus-based
+   editing. Currently deferred; comonadic `extend` and `duplicate` partially address
+   the use cases.
+
+3. **Pattern morphisms** — Explicit `PatternMorphism v w` types with `homomorphism`
+   and `forget` combinators are planned as future work for categorical reasoning.
+
+4. **Standard view instances** — Named instances like `DirectedView` and `UndirectedView`
+   are planned to reduce boilerplate for the common cases.
+
+## Alternatives
+
+**Typed graph representations** — encoding node/relationship/walk distinction in the
+type system (e.g. GADTs indexed by sort) was rejected. `Pattern v`'s uniform-value
+architecture is load-bearing for typeclass instances, and sort indexing would require
+either a parallel type or a substantial rewrite. The runtime cost of kind predicates
+is acceptable.
+
+**Forcing interpretation at construction** — building a `Graph` type with committed
+semantics at the constructor site was rejected in favor of the substrate posture.
+Post-hoc interpretation via views is more flexible without being more complex.

--- a/proposals/design/RFC-003-gram-notation-semantics.md
+++ b/proposals/design/RFC-003-gram-notation-semantics.md
@@ -1,0 +1,293 @@
+# RFC-003: Gram Notation Semantics
+
+**Status:** accepted
+**Date:** 2025-11-01
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/design/SEMANTICS.md`](SEMANTICS.md), [`proposals/design/EXTENDED-SEMANTICS.md`](EXTENDED-SEMANTICS.md)
+**Related modules:** `Gram.Core`, `Gram.Parser`, `Gram.Serializer`
+
+## Summary
+
+Gram notation is the textual serialization format for `Pattern Subject`. It supports two
+complementary syntaxes — **pattern notation** using `[...]` brackets and **path notation**
+using `(nodes)` and relationship arrows — that can be freely mixed in a single file. This
+RFC specifies the semantic rules that govern how gram notation creates, references, and
+constrains `Pattern Subject` values.
+
+## Motivation
+
+A serialization format for graphs must resolve several questions: when does a syntax
+element define a new entity versus reference an existing one? What does it mean to use
+the same identifier twice? How do path-style traversals and declarative bracket notation
+interoperate? Gram notation answers these questions with a small, consistent rule set
+that applies uniformly across both notations.
+
+## Design
+
+### Core Vocabulary
+
+**Identifier** — a symbol that names a specific pattern instance. Identifiers must be
+globally unique within a file: each identifier can be defined exactly once.
+
+**Label** — a type marker for patterns (e.g. `:Person`, `:KNOWS`). Labels denote types
+and can be used freely on multiple patterns.
+
+**Anonymous element** — a pattern with no identifier. Each `[]` or `()` occurrence is
+a distinct instance, even if structurally identical.
+
+### Pattern Notation
+
+Pattern notation uses brackets `[...]` for all pattern construction.
+
+#### The Definition Rule
+
+**Brackets create definitions; bare identifiers create references.**
+
+```
+[a]              -- defines pattern 'a' (empty, no elements)
+[a {k:"v"}]      -- defines 'a' with property k="v"
+[a:Label]        -- defines 'a' with label Label
+
+[b | a]          -- defines 'b'; 'a' appears bare → references 'a'
+[b | [a]]        -- defines both 'b' and 'a' (inline nested definition)
+[b | [a], a]     -- defines 'b' and 'a' inline; then references 'a'
+```
+
+The separator `|` divides the subject (identity, labels, properties) from the elements
+(the content sequence).
+
+#### Single Definition Constraint
+
+Each identified pattern can only be defined once within a file:
+
+```
+[a {k:"v"}]    -- defines 'a'
+[b | a]        -- OK: references 'a'
+[a {k2:"v2"}] -- ERROR: DuplicateDefinition 'a'
+[c | [a]]      -- ERROR: DuplicateDefinition 'a'
+```
+
+#### Immutability
+
+Once defined, a pattern's structure, labels, and properties cannot be changed:
+
+```
+[a {k:"v"}]    -- initial definition
+[a:Thing]      -- ERROR: DuplicateDefinition 'a' (attempt to add label)
+[a | b]        -- ERROR: DuplicateDefinition 'a' (attempt to add elements)
+```
+
+#### No Direct Self-Reference
+
+A pattern cannot contain itself as a direct element:
+
+```
+[a | a]        -- ERROR: SelfReference 'a'
+[a | [b | a]]  -- OK: 'a' referenced indirectly through 'b'
+```
+
+#### Forward References
+
+References to patterns defined later in the file are allowed:
+
+```
+[a | b]        -- OK: 'b' defined below
+[b {k:"v"}]    -- definition of 'b'
+```
+
+#### Anonymous Patterns
+
+Each occurrence of `[]` (or `[{...}]`, `[:Label]`, etc.) is a distinct pattern instance:
+
+```
+[x | []]       -- one anonymous empty element
+[y | [], []]   -- two different anonymous empty elements
+[z | [{k:"v"}]] -- anonymous element with properties
+```
+
+Two anonymous patterns are always distinct even if structurally identical.
+
+### Path Notation
+
+Path notation uses Cypher-style `(node)` and `-[rel]->` syntax for declaring
+graph-structured patterns as traversals.
+
+#### Basic Syntax
+
+```
+(a)                    -- node 'a'
+(a:Person)             -- node 'a' with label 'Person'
+(a)-[r]->(b)           -- directed relationship 'r' from 'a' to 'b'
+(a)<-[r]-(b)           -- directed relationship 'r' from 'b' to 'a'
+(a)-[:knows]->(b)      -- anonymous relationship with label 'knows'
+(a)-[k:knows]->(b)     -- identified relationship 'k' with label 'knows'
+```
+
+Relationships only exist between nodes; they cannot appear standalone.
+
+#### First-Appearance Definition
+
+In path notation, the first appearance of an identifier defines it:
+
+```
+(a)-[r1]->(b)          -- defines: a, r1, b
+(b)-[r2]->(c)          -- defines: r2, c  (b already defined)
+(a)-[r3]->(c)          -- defines: r3     (a and c already defined)
+```
+
+Subsequent appearances of the same identifier are references.
+
+#### Direction Encoding
+
+Path direction maps to element order in pattern notation. `element[0]` is the source,
+`element[1]` is the target:
+
+```
+(a)-[r]->(b)           -- forward: translates to [r | a, b]
+(a)<-[r]-(b)           -- reverse: translates to [r | b, a]
+
+(a)-[r1]->(b)<-[r2]-(c)
+-- translates to: [ | [r1 | a, b], [r2 | c, b]]
+```
+
+#### Cyclic Paths
+
+Relationships can be referenced within cycles when the endpoints match:
+
+```
+(a)-[r1]->(b)-[r2]->(a)-[r1]->(b)
+-- first r1: defines [r1 | a, b]
+-- second r1: references same relationship (valid: same endpoints)
+```
+
+### Pattern-Path Integration
+
+The two notations can be freely mixed. Paths translate to anonymous patterns containing
+relationship patterns:
+
+```
+(a)-[r]->(b)                       -- translates to: [ | [r | a, b]]
+(a)-[r1]->(b)-[r2]->(c)            -- translates to: [ | [r1 | a, b], [r2 | b, c]]
+[p | (a)-[r1]->(b)-[r2]->(c)]      -- named path: [p | [r1 | a, b], [r2 | b, c]]
+```
+
+#### Patterns as Path Nodes
+
+Any pattern (not just atoms) can serve as a node in path notation:
+
+```
+[team | alice, bob]
+[project | frontend, backend]
+(team)-[:works_on]->(project)      -- composite patterns relate to each other
+```
+
+This enables multi-level modeling where composites and atoms can freely interconnect.
+
+#### Meta-Relationships
+
+Identified relationships can be reused as nodes:
+
+```
+(alice)-[k:knows]->(bob)           -- defines relationship 'k'
+(k)-[:type_of]->(social)           -- 'k' used as a node in another relationship
+```
+
+### Semantic Constraints
+
+#### Cross-Notation Consistency
+
+Definitions must be consistent regardless of which notation is used first:
+
+```
+[k | a, b]                         -- defines 'k' as pattern [k | a, b]
+(a)-[k]->(c)                       -- ERROR: k already defined with [a,b], not [a,c]
+
+(a)-[k]->(b)                       -- defines 'k' as [k | a, b]
+[k | a, b]                         -- OK: same definition, consistent
+[k | x, y]                         -- ERROR: different content
+```
+
+#### Path Notation Arity Constraint
+
+When a pattern defined in pattern notation is used as a relationship in path notation,
+its arity must be exactly 2:
+
+```
+[r | a, b]         -- defines 'r' with arity 2
+(a)-[r]->(b)       -- OK: 'r' used as relationship (arity 2)
+
+[k | a, b, c]      -- defines 'k' with arity 3
+(a)-[k]->(b)       -- ERROR: InconsistentDefinition 'k' (expected arity 2)
+```
+
+#### Anonymous Relationship Uniqueness
+
+Each anonymous relationship is a distinct instance:
+
+```
+(alice)-[:knows]->(bob)
+(alice)-[:knows]->(bob)            -- two different relationships, not one
+```
+
+### Error Cases
+
+| Error | Cause |
+|-------|-------|
+| `DuplicateDefinition 'a'` | Identifier `a` defined more than once |
+| `UndefinedReference 'c'` | Bare identifier `c` never defined anywhere in file |
+| `SelfReference 'a'` | `[a \| a]` — pattern directly contains itself |
+| `InconsistentDefinition 'k'` | Same identifier defined with different content across notations |
+
+### Examples
+
+#### Building a Graph
+
+```
+(alice)-[:knows]->(bob)
+(bob)-[:knows]->(charlie)
+(alice)-[friendship:knows]->(charlie)
+(friendship)-[:strength]->(strong)     -- meta-relationship
+```
+
+#### Hierarchical Structures
+
+```
+[eng_team | alice, bob]
+[product_team | charlie, dana]
+[company | eng_team, product_team]
+(eng_team)-[:collaborates_with]->(product_team)
+(alice)-[:leads]->(eng_team)
+```
+
+#### Named Paths
+
+```
+[review_cycle |
+  (author)-[:writes]->(code)-[:reviewed_by]->(reviewer)
+]
+[process | review_cycle, deployment]
+```
+
+#### Pure Structure (no graph interpretation)
+
+```
+[tree | [leaf], [branch | [leaf], tree]]   -- recursive via reference
+```
+
+## Open Questions
+
+None. Gram notation semantics are fully implemented in `Gram.Parser` and
+`Gram.Serializer`. This RFC documents the implemented behavior.
+
+## Alternatives
+
+**Mutation semantics** — allowing identifiers to be redefined or properties to be
+accumulated across multiple appearances was considered and rejected. Immutability
+makes the format unambiguous: the meaning of any identifier is fixed at its definition
+site, regardless of parse order. This also aligns with the `Subject`-level immutability
+property in the data model.
+
+**Requiring definitions before references** — enforcing lexical order was considered
+but forward references were allowed because gram files are often generated and
+rearranged, and requiring strict ordering would make generated output fragile.

--- a/proposals/design/RFC-004-graph-classifier.md
+++ b/proposals/design/RFC-004-graph-classifier.md
@@ -1,0 +1,213 @@
+# RFC-004: GraphClassifier — Unified, Extensible Graph View
+
+**Status:** draft
+**Date:** 2026-02-19
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/graph-classifier.md`](../graph-classifier.md)
+**Followed by:** RFC-005 (GraphQuery) → RFC-008 (GraphTransform) → RFC-009 (GraphMutation)
+**Related modules:** `Pattern.Graph.GraphLens`, `Pattern.PatternGraph`, `Pattern.Graph.GraphClassifier`
+
+## Summary
+
+Introduce `GraphClassifier` as the unifying abstraction for interpreting `Pattern v` as a
+graph. The canonical graph form — currently split between `GraphLens` (lazy, two-category)
+and `PatternGraph` (eager, four-category) — is reconceived as a *family of views* over a
+single storage substrate (`Pattern v`), where the canonical instance uses `isAtomic` as
+its node predicate and arity-based rules for higher categories. `GraphClassifier` becomes
+the shared vocabulary that unifies `GraphLens` and `PatternGraph` under a single
+classification contract.
+
+## Motivation
+
+`GraphLens` and `PatternGraph` were designed with related but separate concerns:
+
+- **`GraphLens`**: a predicate-based interpretive view. Given a `Pattern v` and a
+  `testNode` predicate, it interprets elements as nodes, relationships, and walks on
+  demand. Classification is lazy — evaluated at query time.
+- **`PatternGraph`**: a materialized container. It eagerly classifies elements into four
+  typed maps (nodes, relationships, walks, annotations) using arity-based logic baked
+  into the `GraphValue` typeclass.
+
+Both share the insight that graph structure is an *interpretation* of `Pattern v`, not
+intrinsic to it — but they express that insight differently and have no shared
+classification vocabulary. The result: two parallel type hierarchies with no common
+interface; `PatternGraph` must be converted to a `GraphLens` to use graph algorithms.
+
+The unifying observation: `PatternGraph` is equivalent to a `GraphLens` with `isAtomic`
+as `testNode`, plus an additional arity-based classification pass that further partitions
+non-nodes into relationships, walks, and annotations. Both are views over `Pattern v`.
+The right design is one storage substrate with a family of views. `GraphClassifier` is
+the value that defines the classification contract for any view.
+
+## Design
+
+### `GraphClass` — a shared, extensible classification vocabulary
+
+```haskell
+data GraphClass extra
+  = GNode
+  | GRelationship
+  | GAnnotation
+  | GWalk
+  | GOther extra
+```
+
+The `extra` type parameter is the user's extension point. The canonical classifier uses
+`()` (unit), making `GOther ()` a named bucket for patterns that don't fit the four
+named categories. A user interested in simplicial complexes would define:
+
+```haskell
+data SimplexClass = Simplex2 | Simplex3 | SimplexN Int
+-- Their classifier produces: GraphClass SimplexClass
+```
+
+**Why walks are a named bucket**: walks are prevalent in graph data (paths, traversals,
+gram path notation) and warrant a first-class bucket. The five named categories correspond
+directly to what gram notation can express and what `PatternGraph` currently stores.
+
+**`GOther` is a bucket, not a rejection**: construction never rejects a pattern. Every
+pattern has a place. Users who want to inspect what landed in `GOther` query `pgOther`.
+
+### `GraphClassifier` — injectable classification logic
+
+```haskell
+data GraphClassifier extra v = GraphClassifier
+  { classify :: Pattern v -> GraphClass extra
+  }
+```
+
+A record of functions, not a typeclass. This makes it a first-class value that can be
+passed, stored, varied at runtime, wrapped with memoization, and composed — more
+portable across language targets than a typeclass.
+
+The canonical classifier for `Pattern Subject`:
+
+```haskell
+canonicalClassifier :: GraphClassifier () Subject
+canonicalClassifier = GraphClassifier { classify = classifyByArity }
+```
+
+where `classifyByArity` implements the arity-based logic currently in `GraphValue`:
+- `elements == []` → `GNode`
+- `length elements == 2` → `GRelationship`
+- `length elements == 1` → `GAnnotation`
+- `length elements >= 3` (with all elements themselves having arity 2) → `GWalk`
+- otherwise → `GOther ()`
+
+### Eager vs. Lazy Evaluation
+
+`GraphClassifier.classify` is a pure function. The implementation decides when to call it:
+
+- **Eager** (`PatternGraph` style): call at insertion time, store in typed maps. O(1) queries.
+- **Lazy** (`GraphLens` style): call at query time. No upfront cost; repeated queries re-evaluate.
+- **Memoized**: call lazily, cache results. Amortized O(1) for repeated queries.
+
+Because `GraphClassifier` is a value passed to the container, expensive predicates can
+be wrapped in a memoizing `GraphClassifier` without changing the container API.
+
+### Relationship to Existing Code
+
+#### `GraphLens` — re-derived from `GraphClassifier`
+
+`GraphLens` with a `testNode` predicate is the two-category specialization of
+`GraphClassifier`. It is re-derived by implementing its operations in terms of
+`GraphClassifier`:
+
+```haskell
+fromTestNode :: (Pattern v -> Bool) -> GraphClassifier () v
+fromTestNode testNode = GraphClassifier
+  { classify = \p -> if testNode p then GNode else GOther ()
+  }
+```
+
+All existing `GraphLens` operations (`nodes`, `relationships`, `walks`, `neighbors`,
+`bfs`, `findPath`, etc.) are preserved with identical signatures, re-implemented to
+delegate to `GraphClassifier` internally. **The public API of `GraphLens` is preserved;
+the internals are re-implemented.**
+
+#### `PatternGraph` — updated, not replaced
+
+`PatternGraph` stays as the canonical eager materialized store. Its classification
+logic is extracted from the `GraphValue` typeclass and moved into
+`canonicalClassifier :: GraphClassifier () Subject`. `GraphValue` is simplified:
+
+```haskell
+-- Before
+class Ord (Id v) => GraphValue v where
+  type Id v
+  identify :: v -> Id v
+  classify :: Pattern v -> PatternClass  -- ← moves out
+
+-- After
+class Ord (Id v) => GraphValue v where
+  type Id v
+  identify :: v -> Id v
+```
+
+`MergeResult` is dropped; construction returns a `PatternGraph v` directly. `PatternClass`
+is replaced by `GraphClass extra`. `Unrecognized` becomes `GOther extra`.
+
+**This is a breaking change to `PatternGraph` and `GraphValue`**, but `PatternGraph` is
+a recent feature (Feature 33) and the change is an improvement.
+
+### Construction Ergonomics
+
+The common path remains simple:
+
+```haskell
+-- Canonical classifier (most users)
+let graph = fromPatterns canonicalClassifier patterns
+
+-- Custom classifier (power users)
+let graph = fromPatterns myClassifier patterns
+```
+
+### What Changes in pattern-hs
+
+| Component | Action | Notes |
+|---|---|---|
+| `Pattern.Graph.GraphClassifier` | **New** | Core new type introduced by this RFC |
+| `Pattern.Graph.GraphClass` | **New** | Replaces `PatternClass`; adds `extra` parameter |
+| `canonicalClassifier` | **New** | `GraphClassifier () Subject`; extracted from `classifyByArity` |
+| `Pattern.Graph.GraphLens` | **Re-derive** | Public API preserved; internals re-implemented |
+| `Pattern.PatternGraph.GraphValue` | **Simplify** | Remove `classify`; retain `identify` |
+| `Pattern.PatternGraph.PatternClass` | **Replace** | With `GraphClass extra` |
+| `Pattern.PatternGraph.MergeResult` | **Remove** | Construction returns `PatternGraph v` directly |
+| `Pattern.PatternGraph.PatternGraph` | **Update** | Accept `GraphClassifier` at construction; add `pgOther` |
+
+## Open Questions
+
+1. **Module placement for `GraphClassifier`** — `Pattern.Graph` (alongside `GraphLens`)
+   or `Pattern.Classify` (its own module)?
+
+2. **`pgOther` storage shape** — `Map (Id v) (Pattern v)` loses the `extra` type
+   information. `Map (Id v) (extra, Pattern v)` preserves it. Worth evaluating during
+   implementation.
+
+## Alternatives
+
+**Typeclass instead of record-of-functions** — A `Classifiable v` typeclass was
+considered. Rejected because a record is more portable to Rust, TypeScript, and Java,
+more composable (wrapper transformations), and more convenient for runtime-variable
+classifiers (e.g. different views of the same graph at different times).
+
+**Keeping `GraphLens` and `PatternGraph` separate** — The status quo was rejected
+because it forces algorithm authors to commit to one representation or the other,
+prevents sharing classification logic, and creates a conceptual gap that users have
+to bridge manually.
+
+**Normalization in the classifier** — transforming arbitrary `Pattern v` into canonical
+graph form (e.g. a sequence of nodes into a walk) was considered and deferred. This RFC
+describes the target structure; transformation paths into it belong in a separate RFC.
+
+## Portability Notes
+
+`GraphClass extra` ports to all targets:
+
+| Language | `()` / unit | Enforcement |
+|---|---|---|
+| Haskell | `()` | Compiler: `GOther` takes unit |
+| Rust | `()` | Compiler: `GOther(())` arm required |
+| TypeScript | `null` / `undefined` | Compiler-checked with care |
+| Java | `Void` (as null) | Conventional only |

--- a/proposals/design/RFC-005-graph-query.md
+++ b/proposals/design/RFC-005-graph-query.md
@@ -133,7 +133,7 @@ fromPatternGraph pg = GraphQuery
   , queryRelationships    = Map.elems (pgRelationships pg)
   , queryIncidentRels     = \n -> filter (touches n) (Map.elems (pgRelationships pg))
   , querySource           = \r -> listToMaybe (elements r)
-  , queryTarget           = \r -> listToMaybe (tail (elements r))
+  , queryTarget           = \r -> listToMaybe (drop 1 (elements r))
   , queryDegree           = \n -> length (filter (touches n) (Map.elems (pgRelationships pg)))
   , queryNodeById         = \i -> Map.lookup i (pgNodes pg)
   , queryRelationshipById = \i -> Map.lookup i (pgRelationships pg)
@@ -142,7 +142,8 @@ fromPatternGraph pg = GraphQuery
       ++ filter (elem p . elements) (Map.elems (pgWalks pg))
       ++ filter (elem p . elements) (Map.elems (pgAnnotations pg))
   }
-  where touches n r = querySource q r == Just n || queryTarget q r == Just n
+  where touches n r = listToMaybe (elements r) == Just n
+                   || listToMaybe (drop 1 (elements r)) == Just n
 ```
 
 `fromPatternGraph` does not go through `GraphLens`. It reads from typed maps with O(log n)

--- a/proposals/design/RFC-005-graph-query.md
+++ b/proposals/design/RFC-005-graph-query.md
@@ -1,0 +1,266 @@
+# RFC-005: GraphQuery — Portable, Composable Graph Query Interface
+
+**Status:** draft
+**Date:** 2026-02-19
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/graph-query.md`](../graph-query.md)
+**Depends on:** RFC-004 (GraphClassifier)
+**Followed by:** RFC-008 (GraphTransform) → RFC-009 (GraphMutation)
+**Related modules:** `Pattern.Graph.GraphQuery`, `Pattern.Graph.Algorithms`, `Pattern.PatternGraph`
+
+## Summary
+
+Introduce `GraphQuery v` as a record-of-functions that abstracts over graph traversal and
+lookup, decoupling graph algorithms from any particular graph representation. Algorithms
+are expressed once against `GraphQuery v` and apply to `GraphLens`, `PatternGraph`, a
+database-backed graph, a filtered frame, or any other representation that can produce a
+`GraphQuery v`. Traversal direction and weighting are expressed as a `TraversalWeight`
+function supplied per-call — not embedded in `GraphQuery` — making directed, undirected,
+and weighted traversal constraints applied to the general case.
+
+## Motivation
+
+Graph algorithms currently live on `GraphLens` and take a `GraphLens` as their first
+argument. This means:
+
+- Algorithms are unavailable to `PatternGraph` without converting to `GraphLens` via
+  `toGraphLens`, which materializes a scope pattern and loses categorical structure.
+- Algorithms are unavailable to any non-`GraphLens` representation without wrapping,
+  which may not be natural or efficient.
+- Adding a new graph representation requires re-implementing or re-exposing all algorithms.
+
+The deeper issue: graph algorithms don't need a `GraphLens`. They need a small set of
+traversal primitives — neighbor enumeration, endpoint access, node lookup.
+
+A record-of-functions representing a query interface is a first-class value. This enables:
+
+- **Graph frames** — a view over a subset of a larger graph, filtered by label, time
+  window, or property predicate, is just a `GraphQuery v` wrapping another `GraphQuery v`
+  with filter logic.
+- **Database-backed graphs** — a `GraphQuery v` can close over a database connection.
+  The algorithm layer never knows whether it operates in memory or over a network.
+- **Logging, caching, projection** — all expressible as `GraphQuery v -> GraphQuery v`
+  transformations.
+
+## Design
+
+### `TraversalWeight` — Generalized Traversal Policy
+
+Direction and weight are properties of *how* an algorithm traverses, not of graph
+structure. A `TraversalWeight` function encodes both:
+
+```haskell
+data TraversalDirection = Forward | Backward
+
+type TraversalWeight v = Pattern v -> TraversalDirection -> Double
+```
+
+Canonical values:
+
+```haskell
+undirected :: TraversalWeight v
+undirected _ _ = 1.0
+
+directed :: TraversalWeight v
+directed _ Forward  = 1.0
+directed _ Backward = 1/0   -- infinity blocks reverse traversal
+
+directedReverse :: TraversalWeight v
+directedReverse _ Forward  = 1/0
+directedReverse _ Backward = 1.0
+```
+
+"Directed vs. undirected" is not a distinct graph type — it is a `TraversalWeight`
+supplied at the call site.
+
+### `GraphQuery` — the Interface
+
+```haskell
+data GraphQuery v = GraphQuery
+  { queryNodes            :: [Pattern v]
+  , queryRelationships    :: [Pattern v]
+  , queryIncidentRels     :: Pattern v -> [Pattern v]
+  , querySource           :: Pattern v -> Maybe (Pattern v)
+  , queryTarget           :: Pattern v -> Maybe (Pattern v)
+  , queryDegree           :: Pattern v -> Int
+  , queryNodeById         :: Id v -> Maybe (Pattern v)
+  , queryRelationshipById :: Id v -> Maybe (Pattern v)
+  , queryContainers       :: Pattern v -> [Pattern v]
+  }
+```
+
+**`queryNeighbors` is absent**: algorithms derive reachable neighbors from
+`queryIncidentRels`, `querySource`, `queryTarget`, and the supplied `TraversalWeight`.
+
+**`queryDegree`** is derivable from `queryIncidentRels` but included explicitly because
+implementations may provide O(1) versions (e.g. a database with a degree index).
+
+**`queryContainers`** returns all higher-order structures that directly contain a given
+element — the relationships a node participates in, the walks those relationships belong
+to, the annotations attached to an element. This is the upward traversal dual to
+downward decomposition. Required by RFC-009 (GraphMutation) for coherent deletion;
+independently useful for impact analysis and pattern matching.
+
+`Id v` comes from the `GraphValue` typeclass (`identify :: v -> Id v`).
+
+### Constructing a `GraphQuery`
+
+#### From `GraphLens`
+
+```haskell
+fromGraphLens :: Eq v => GraphLens v -> GraphQuery v
+fromGraphLens lens = GraphQuery
+  { queryNodes            = nodes lens
+  , queryRelationships    = relationships lens
+  , queryIncidentRels     = incidentRels lens
+  , querySource           = source lens
+  , queryTarget           = target lens
+  , queryDegree           = degree lens
+  , queryNodeById         = \i -> find (\p -> identify (value p) == i) (nodes lens)
+  , queryRelationshipById = \i -> find (\p -> identify (value p) == i) (relationships lens)
+  , queryContainers       = \p -> filter (elem p . elements) (relationships lens)
+                                ++ filter (elem p . elements) (walks lens)
+  }
+```
+
+#### From `PatternGraph`
+
+```haskell
+fromPatternGraph :: (GraphValue v, Eq v) => PatternGraph v -> GraphQuery v
+fromPatternGraph pg = GraphQuery
+  { queryNodes            = Map.elems (pgNodes pg)
+  , queryRelationships    = Map.elems (pgRelationships pg)
+  , queryIncidentRels     = \n -> filter (touches n) (Map.elems (pgRelationships pg))
+  , querySource           = \r -> listToMaybe (elements r)
+  , queryTarget           = \r -> listToMaybe (tail (elements r))
+  , queryDegree           = \n -> length (filter (touches n) (Map.elems (pgRelationships pg)))
+  , queryNodeById         = \i -> Map.lookup i (pgNodes pg)
+  , queryRelationshipById = \i -> Map.lookup i (pgRelationships pg)
+  , queryContainers       = \p ->
+      filter (elem p . elements) (Map.elems (pgRelationships pg))
+      ++ filter (elem p . elements) (Map.elems (pgWalks pg))
+      ++ filter (elem p . elements) (Map.elems (pgAnnotations pg))
+  }
+  where touches n r = querySource q r == Just n || queryTarget q r == Just n
+```
+
+`fromPatternGraph` does not go through `GraphLens`. It reads from typed maps with O(log n)
+lookups rather than O(n) scans.
+
+#### Custom (Database, Frame, etc.)
+
+Any value that can supply the required functions produces a `GraphQuery v`. No
+inheritance, no typeclass instance, no wrapping required.
+
+### Algorithms
+
+Graph algorithms live in `Pattern.Graph.Algorithms`, each accepting a `GraphQuery v` as
+their first argument. Traversal algorithms also accept `TraversalWeight v`:
+
+```haskell
+-- Traversal
+bfs :: Ord (Id v) => GraphQuery v -> TraversalWeight v -> Pattern v -> [Pattern v]
+dfs :: Ord (Id v) => GraphQuery v -> TraversalWeight v -> Pattern v -> [Pattern v]
+
+-- Paths
+shortestPath :: Ord (Id v) => GraphQuery v -> TraversalWeight v
+             -> Pattern v -> Pattern v -> Maybe [Pattern v]
+hasPath      :: Ord (Id v) => GraphQuery v -> TraversalWeight v
+             -> Pattern v -> Pattern v -> Bool
+allPaths     :: Ord (Id v) => GraphQuery v -> TraversalWeight v
+             -> Pattern v -> Pattern v -> [[Pattern v]]
+
+-- Structural
+connectedComponents :: Ord (Id v) => GraphQuery v -> TraversalWeight v -> [[Pattern v]]
+topologicalSort     :: Ord (Id v) => GraphQuery v -> Maybe [Pattern v]
+hasCycle            :: Ord (Id v) => GraphQuery v -> Bool
+
+-- Spanning
+minimumSpanningTree :: Ord (Id v) => GraphQuery v -> TraversalWeight v -> [Pattern v]
+
+-- Centrality (representative signatures; each has additional tuning parameters)
+degreeCentrality      :: Ord (Id v) => GraphQuery v -> Map (Id v) Double
+betweennessCentrality :: Ord (Id v) => GraphQuery v -> TraversalWeight v -> Map (Id v) Double
+```
+
+Existing `GraphLens` algorithm functions (`bfs`, `findPath`, `connectedComponents`) are
+retained as backward-compatible wrappers that call `fromGraphLens` and default to
+`undirected`.
+
+### Context Query Helpers
+
+Derived functions for common "what is the context of this element?" questions, built on
+`GraphQuery` primitives:
+
+```haskell
+queryAnnotationsOf   :: GraphClassifier extra v -> GraphQuery v -> Pattern v -> [Pattern v]
+queryWalksContaining :: GraphClassifier extra v -> GraphQuery v -> Pattern v -> [Pattern v]
+queryCoMembers       :: GraphQuery v -> Pattern v -> Pattern v -> [Pattern v]
+```
+
+Required by RFC-008 (GraphTransform) for context-aware mapping.
+
+### Composability Patterns
+
+#### Framing (Subgraph Projection)
+
+```haskell
+frameQuery :: (Pattern v -> Bool) -> GraphQuery v -> GraphQuery v
+frameQuery include base = GraphQuery
+  { queryNodes     = filter include . queryNodes base
+  , queryIncidentRels = \n -> filter (all include . endpoints) . queryIncidentRels base n
+  , ...
+  }
+```
+
+#### Logging / Instrumentation
+
+```haskell
+tracingQuery :: (String -> IO ()) -> GraphQuery v -> GraphQuery v
+```
+
+#### Caching
+
+```haskell
+memoizeIncidentRels :: Ord (Id v) => GraphQuery v -> GraphQuery v
+```
+
+These compose: `memoizeIncidentRels . frameQuery predicate $ fromPatternGraph pg` is a
+valid, well-typed expression.
+
+### What Changes in pattern-hs
+
+| Component | Action | Notes |
+|---|---|---|
+| `Pattern.Graph.GraphQuery` | **New** | Core new type; includes `queryContainers` |
+| `Pattern.Graph.TraversalWeight` | **New** | Traversal policy type; canonical values provided |
+| `Pattern.Graph.Algorithms` | **New** | All graph algorithms over `GraphQuery v + TraversalWeight v` |
+| Context query helpers | **New** | `queryAnnotationsOf`, `queryWalksContaining`, `queryCoMembers` |
+| `Pattern.Graph.fromGraphLens` | **New** | Constructs `GraphQuery v` from `GraphLens v` |
+| `Pattern.PatternGraph.fromPatternGraph` | **New** | Constructs `GraphQuery v` from `PatternGraph v` |
+| `Pattern.PatternGraph.toGraphLens` | **Retire** | Superseded by `fromPatternGraph` |
+| Existing `GraphLens` algorithms | **Retain as wrappers** | Delegate to `Algorithms` with `undirected` default |
+
+## Open Questions
+
+1. **Bulk adjacency for iterative algorithms** — PageRank, Louvain, DeepWalk require
+   memory-local adjacency structures, not repeated `queryIncidentRels` calls. A
+   `Pattern.Graph.Algorithms.Bulk` module materializing an unboxed vector-based
+   adjacency list is recommended. Should not be deferred past the first
+   performance-sensitive algorithm.
+
+2. **Module granularity** — one `Pattern.Graph.Algorithms` module, or
+   sub-modules by category (`Algorithms.Path`, `Algorithms.Centrality`, etc.)?
+
+## Alternatives
+
+**Typeclass instead of record-of-functions** — Consistent with `GraphClassifier` design,
+rejected for the same portability and composability reasons.
+
+**`queryNeighbors` as a field** — "neighbors" is not a fixed concept because it depends
+on traversal direction. Algorithms derive reachable neighbors from `queryIncidentRels`
+plus `TraversalWeight`.
+
+**Pattern matching in scope** — Cypher-style pattern matching is a query language layer
+above `GraphQuery`, not part of the interface.

--- a/proposals/design/RFC-006-scope-unification.md
+++ b/proposals/design/RFC-006-scope-unification.md
@@ -239,7 +239,7 @@ convention going forward.
 
 ### Implementation Sequence
 
-1. Confirm `findInSubtree` and `subtreeElements` exist in `Pattern.Core`
+1. Confirm `subtreeElementAt` and `subtreeElements` exist in `Pattern.Core`
 2. Add `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toScopeDict` to `Pattern.Core`
 3. Add `paraWithScope`; redefine `para` in terms of it; run existing `para` test suite
 4. Add `scopeDictFromGraphView` to `Pattern.Graph.Transform`; run existing `paraGraph` tests

--- a/proposals/design/RFC-006-scope-unification.md
+++ b/proposals/design/RFC-006-scope-unification.md
@@ -1,0 +1,271 @@
+# RFC-006: Scope Unification — ScopeQuery and paraWithScope
+
+**Status:** draft
+**Date:** 2026-03-17
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/scope-unification-proposal.md`](../scope-unification-proposal.md)
+**Depends on:** RFC-005 (GraphQuery)
+**Followed by:** RFC-007 (RepresentationMap)
+**Related modules:** `Pattern.Core`, `Pattern.Graph.Transform`
+
+## Summary
+
+Introduce `ScopeQuery` as a typeclass abstracting over *what is in scope* for a fold
+operation, and `paraWithScope` as the unified primitive fold that subsumes both `para`
+and `paraGraph` as derivable special cases. The insight: `para` and `paraGraph` are the
+same operation at different scope boundaries, where the scope boundary is determined by
+a containing element, not by the query interface used to access it.
+
+This is a purely additive refactoring. No existing API is removed or broken. No behavior
+changes.
+
+## Motivation
+
+`pattern-hs` has two fold operations with overlapping semantics:
+
+- **`para`** — a paramorphism over `Pattern v`. Each node receives its own value and the
+  bottom-up results of its direct children. Scope is implicit: the fold sees only the
+  immediate subtree.
+- **`paraGraph`** — a fold over a `GraphView`. Each element receives a `GraphQuery v`
+  giving access to the full graph context. Scope is the enclosing `GraphView`.
+
+These look like different operations, but they are the same operation at different scope
+boundaries. The difference is not "pattern vs. graph" — it is **which containing element
+defines the scope**: in `para`, scope is the current node's immediate children; in
+`paraGraph`, scope is the enclosing `GraphView` element.
+
+Making this explicit has two benefits:
+1. `para` and `paraGraph` can be redefined as derived operations, eliminating duplication.
+2. New scope kinds (a gram document, a project corpus, a subgraph) can be introduced
+   without adding new fold primitives.
+
+## Design
+
+### `ScopeQuery` — the Typeclass
+
+A `ScopeQuery` is a query interface into a scope defined by some containing element:
+
+```haskell
+-- Pattern.Core
+
+class ScopeQuery q v where
+  type ScopeId q v
+
+  containers  :: q v -> Pattern v -> [Pattern v]
+    -- ^ patterns that directly contain this element within the scope
+  siblings    :: q v -> Pattern v -> [Pattern v]
+    -- ^ co-elements of the same immediate parent within the scope
+  byIdentity  :: q v -> ScopeId q v -> Maybe (Pattern v)
+    -- ^ look up any element in scope by identity
+  allElements :: q v -> [Pattern v]
+    -- ^ enumerate all elements within the scope
+```
+
+The type variable `q` is the scope query implementation. Different containers instantiate
+`q` differently: `TrivialScope` for subtree scope, graph-view-backed dictionaries for
+graph-wide answers, or any future scope the caller defines. The caller is always
+responsible for constructing the scope — it is not inferred from the fold target.
+
+### `TrivialScope` — Immediate-Children Scope
+
+The simplest instance. Scope is a single `Pattern v` and covers only its subtree:
+
+```haskell
+-- Pattern.Core
+
+newtype TrivialScope v = TrivialScope (Pattern v)
+
+trivialScope :: Pattern v -> TrivialScope v
+trivialScope = TrivialScope
+
+instance ScopeQuery TrivialScope v where
+  type ScopeId TrivialScope v = Int
+  containers  _ _               = []   -- no parent information in trivial scope
+  siblings    _ _               = []   -- no sibling information in trivial scope
+  byIdentity  (TrivialScope p) i = subtreeElementAt p i
+  allElements (TrivialScope p)   = subtreeElements p
+```
+
+### `ScopeDict` — First-Class Value Form
+
+For situations where a `ScopeQuery` instance must be stored in a data structure or passed
+to a non-polymorphic function, a `ScopeDict` record is provided alongside the typeclass:
+
+```haskell
+-- Pattern.Core
+
+data ScopeDict i v = ScopeDict
+  { dictContainers  :: Pattern v -> [Pattern v]
+  , dictSiblings    :: Pattern v -> [Pattern v]
+  , dictByIdentity  :: i -> Maybe (Pattern v)
+  , dictAllElements :: [Pattern v]
+  }
+
+instance ScopeQuery (ScopeDict i) v where
+  type ScopeId (ScopeDict i) v = i
+  containers  d = dictContainers d
+  siblings    d = dictSiblings d
+  byIdentity  d = dictByIdentity d
+  allElements d = dictAllElements d
+
+toScopeDict :: ScopeQuery q v => q v -> ScopeDict (ScopeId q v) v
+toScopeDict q = ScopeDict
+  { dictContainers  = containers q
+  , dictSiblings    = siblings q
+  , dictByIdentity  = byIdentity q
+  , dictAllElements = allElements q
+  }
+```
+
+`ScopeDict` is an escape hatch, not the primary interface. Prefer the typeclass form in
+function signatures; use `ScopeDict` only when a first-class value is genuinely needed.
+
+### Graph-Wide Scope Reification
+
+The existing `GraphQuery v` record alone is not sufficient to answer generic `ScopeQuery`
+operations such as `allElements` and graph-wide `byIdentity`, because it only exposes
+nodes, relationships, and graph-topology queries. A full `GraphView` (see RFC-008)
+contains the complete classified element set:
+
+```haskell
+-- Pattern.Graph.Transform
+
+scopeDictFromGraphView :: GraphValue v => GraphView extra v -> ScopeDict (Id v) v
+```
+
+This design makes an important invariant explicit: graph-wide `byIdentity` is well-defined
+only when `Id v` is unique across the classified `GraphView` snapshot. Duplicate
+identities should be rejected rather than silently collapsed.
+
+### `paraWithScope` — the Unified Primitive
+
+```haskell
+-- Pattern.Core
+
+paraWithScope
+  :: ScopeQuery q v
+  => q v                               -- scope: the containing element's query interface
+  -> (q v -> Pattern v -> [r] -> r)   -- algebra: scope, current node, child results
+  -> Pattern v                         -- root pattern to fold over
+  -> r
+```
+
+The algebra receives three arguments: the scope query (for lookups and context), the
+current pattern node, and the bottom-up results of the current node's direct children.
+The fold is bottom-up. The scope is fixed for the duration of the fold.
+
+### Deriving `para` and `paraGraph`
+
+```haskell
+-- Pattern.Core
+
+para :: (Pattern v -> [r] -> r) -> Pattern v -> r
+para f p = paraWithScope (trivialScope p) (\_ pat rs -> f pat rs) p
+```
+
+`para` is unchanged at every call site. The `ScopeQuery` parameter is hidden behind
+`trivialScope`. Behavior is identical to the current implementation.
+
+```haskell
+-- Pattern.Graph
+
+paraGraph
+  :: (GraphQuery v -> Pattern v -> [r] -> r)
+  -> GraphView extra v
+  -> Map (Id v) r
+paraGraph f view = ...
+```
+
+`paraGraph` is preserved as a graph-specific wrapper. It folds over a classified
+`GraphView`, not a single rooted `Pattern`, and passes `GraphQuery v` into the algebra —
+preserving the existing scheduling and cycle-softening semantics. The unified generic
+scope layer is exposed separately via `scopeDictFromGraphView`.
+
+### `GraphScope` — Graph-Topology Extension (Follow-on)
+
+A natural follow-on is a `GraphScope` subclass adding operations meaningful only when
+scoped patterns are graph-classified (`GNode`, `GRelationship`, etc.):
+
+```haskell
+-- Pattern.Graph
+
+class ScopeQuery q v => GraphScope q v where
+  source    :: q v -> Pattern v -> Maybe (Pattern v)
+  target    :: q v -> Pattern v -> Maybe (Pattern v)
+  incidents :: q v -> Pattern v -> [Pattern v]
+  degree    :: q v -> Pattern v -> Int
+  nodes     :: q v -> [Pattern v]
+  rels      :: q v -> [Pattern v]
+```
+
+This RFC does not implement `GraphScope`; it stops at the generic scope layer.
+
+### Interface Convention
+
+This RFC establishes the going-forward convention for new interfaces in `pattern-hs`:
+
+1. Define the interface as a typeclass
+2. Provide a `*Dict` record as the first-class value form, with a `toScopeDict`
+   reification function
+3. Reify existing records into the new interface when they satisfy it without losing
+   information
+4. Document the cross-language correspondence
+
+**Cross-language correspondence:**
+
+| Haskell | Rust | Python / TypeScript (via WASM) |
+|---|---|---|
+| Typeclass | Trait | Protocol / Interface |
+| `*Dict` record | Struct implementing trait | Concrete class |
+| `toScopeDict` | `impl Trait for Struct` | Protocol conformance |
+
+Existing `GraphQuery` and `GraphClassifier` records are **not** converted to typeclasses
+— that would be a breaking change with limited benefit. New interfaces follow this
+convention going forward.
+
+### Module Placement
+
+| Definition | Module | Action |
+|---|---|---|
+| `ScopeQuery` typeclass | `Pattern.Core` | **New** |
+| `TrivialScope` + `trivialScope` | `Pattern.Core` | **New** |
+| `ScopeDict` + `toScopeDict` | `Pattern.Core` | **New** |
+| `paraWithScope` | `Pattern.Core` | **New** |
+| `para` | `Pattern.Core` | **Redefine** (no API change) |
+| `scopeDictFromGraphView` | `Pattern.Graph.Transform` | **New** |
+| Internal `GraphViewScope` adapter | `Pattern.Graph.Transform` | **New (internal)** |
+| `paraGraph` | `Pattern.Graph.Transform` | **Preserve wrapper** (no API change) |
+
+### Implementation Sequence
+
+1. Confirm `findInSubtree` and `subtreeElements` exist in `Pattern.Core`
+2. Add `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toScopeDict` to `Pattern.Core`
+3. Add `paraWithScope`; redefine `para` in terms of it; run existing `para` test suite
+4. Add `scopeDictFromGraphView` to `Pattern.Graph.Transform`; run existing `paraGraph` tests
+
+### Acceptance Criteria
+
+1. `ScopeQuery`, `TrivialScope`, `ScopeDict`, `toScopeDict`, `paraWithScope` are in
+   `Pattern.Core` and exported.
+2. `scopeDictFromGraphView` is in `Pattern.Graph.Transform` and exported.
+3. `para` and `paraGraph` pass their existing test suites without modification.
+4. Full `pattern-hs` test suite passes with no failures.
+5. No existing call sites required changes.
+
+## Open Questions
+
+None. The design is fully specified above.
+
+## Alternatives
+
+**Existential wrapper over `ScopeQuery q v`** — preserving polymorphism through an
+existential rather than using `ScopeDict` was considered. Rejected: the aspect
+combinators are closed operations on scopes (scopes in, scopes out), and the concrete
+record representation is sufficient. The existential wrapper would add machinery without
+payoff at the framework layer.
+
+**Unifying `para` and `paraGraph` into a single function** — by making `paraGraph` also
+call `paraWithScope` directly. Rejected to preserve `paraGraph`'s graph-specific
+scheduling and cycle-softening semantics, which are meaningfully different from a
+simple bottom-up fold over a rooted `Pattern`.

--- a/proposals/design/RFC-007-representation-map.md
+++ b/proposals/design/RFC-007-representation-map.md
@@ -1,0 +1,240 @@
+# RFC-007: RepresentationMap — Invertible Shape Isomorphisms
+
+**Status:** draft
+**Date:** 2026-03-17
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/representation-map-proposal.md`](../representation-map-proposal.md)
+**Depends on:** RFC-006 (ScopeQuery / paraWithScope), RFC-008 (GraphTransform, for `GraphTransform` primitives)
+**Followed by:** Rust port (`pattern-rs`) → CLI surface (`pato canonicalize`)
+**Related modules:** `Pattern.Core`, `Pattern.RepresentationMap`, `Pattern.Graph.Transform`
+
+## Summary
+
+Introduce `RepresentationMap` as a named, invertible, composable isomorphism between two
+*kinds of shape* — named, recognizable shapes of `Pattern v` — where both kinds are
+subtypes of `Pattern v` and the isomorphism is witnessed by a machine-checkable
+round-trip property. Graph form is one common codomain, but any two kinds of shape can be
+related by a `RepresentationMap`.
+
+## Motivation
+
+### The Two-Register Problem
+
+The same information can be held in a form optimised for reading (nested pattern structure)
+or a form optimised for querying (flat graph topology):
+
+- **Pattern form** — nesting makes local structure immediately visible; optimised for
+  authoring, reading, and sequential processing by humans and LLMs top-to-bottom.
+- **Graph form** — flat topology makes global structure immediately traversable; optimised
+  for querying, graph algorithms, and integration with graph-native tools.
+
+Without explicit machinery, converting between forms requires either ad-hoc one-off
+transformations (hard to invert, hard to compose) or committing to one form forever.
+
+`RepresentationMap` makes the relationship explicit: it names the two kinds of shape,
+declares the structural conventions that make round-tripping work, and provides a
+machine-checkable witness to correctness.
+
+### Use Cases
+
+- Nested diagnostic pattern ↔ flat node-relationship diagnostic graph
+- Positional sequence encoding ↔ labeled property encoding
+- Hierarchy-as-nesting ↔ hierarchy-as-membership-edges
+- Compact scalar representation ↔ expanded structural representation
+
+## Design
+
+### Foundational Principle: Scope is an Element
+
+**Scope is not a query interface. Scope is an element. An element defines the scope of
+everything it contains.**
+
+A pattern element is a scope for its direct elements and for everything transitively
+nested within it. Query interfaces are not *the scope* — they are efficient accessors
+into a scope defined by a containing element. The caller decides what the scope
+container is and constructs the appropriate query from it.
+
+Both `para` and `paraGraph` are instances of the same general operation: a fold where
+the folding function has access to child results *and* to the query interface for the
+broader containing scope. See RFC-006 for the unification.
+
+### Kinds of Shape
+
+A **kind of shape** is a named, recognizable shape of `Pattern v` — a description of
+the structural constraints that a pattern must satisfy to be an instance of that kind.
+It is a subtype of `Pattern v` defined by a predicate.
+
+```haskell
+data PatternKind v = PatternKind
+  { kindName    :: Text
+    -- ^ e.g. "DiagnosticPattern", "DiagnosticGraph", "GNode"
+  , kindPred    :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ true iff a pattern is of this kind within a given scope
+  , kindExample :: Pattern v
+    -- ^ canonical example for property-based test generation
+  }
+```
+
+`kindPred` is polymorphic over scope queries: a shape constraint may be purely
+structural (check the pattern itself) or scope-relative (check cross-references within
+the containing scope). Both cases use the same predicate signature.
+
+The graph classification kinds from RFC-004 (`GNode`, `GRelationship`, `GWalk`,
+`GAnnotation`) are kinds of shape in exactly this sense.
+
+### `RepresentationMap`
+
+```haskell
+data RepresentationMap v = RepresentationMap
+  { name        :: Text
+  , domain      :: PatternKind v
+  , codomain    :: PatternKind v
+  , conventions :: [Text]
+    -- ^ named structural decisions that make the round-trip work
+  , forward     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , inverse     :: forall q. ScopeQuery q v => q v -> Pattern v -> Pattern v
+  , roundTrip   :: forall q. ScopeQuery q v => q v -> Pattern v -> Bool
+    -- ^ witness: (inverse q . forward q) p == p for all p of kind domain
+  }
+```
+
+`forward` and `inverse` are polymorphic over scope queries. A transform that needs graph
+topology additionally constrains its scope:
+
+```haskell
+-- A map whose source is graph-shaped needs GraphScope (from RFC-006 follow-on)
+graphAwareForward :: GraphScope q v => q v -> Pattern v -> Pattern v
+```
+
+### Conventions
+
+Invertibility is not free. When a kind of shape does not carry all the information
+needed to reconstruct the source from the target, the forward transform must encode
+structural metadata into the target. These encoding decisions are **conventions** and
+are part of the map's identity. An undocumented convention is a convention that will
+be misread. Conventions are named text; long-term they may be expressed as gram
+annotations on the codomain's schema.
+
+### Composability
+
+Two `RepresentationMap`s compose when the codomain of the first matches the domain of
+the second:
+
+```haskell
+compose :: RepresentationMap v -> RepresentationMap v -> RepresentationMap v
+compose m1 m2 = RepresentationMap
+  { name        = name m1 <> " >>> " <> name m2
+  , domain      = domain m1
+  , codomain    = codomain m2
+  , conventions = conventions m1 <> conventions m2
+  , forward     = \q p -> forward m2 q (forward m1 q p)
+  , inverse     = \q p -> inverse m1 q (inverse m2 q p)
+  , roundTrip   = \q p -> roundTrip m1 q p && roundTrip m2 q p
+  }
+```
+
+### Concrete Example: Diagnostic Map
+
+**Kinds:**
+- `DiagnosticPattern` — a location pattern directly containing a diagnostic pattern
+  directly containing zero or more remediation patterns; labels `Location`, `Diagnostic`,
+  `Remediation`; specific required properties per label.
+- `DiagnosticGraph` — flat atomic patterns with labels `Location`, `Diagnostic`,
+  `Remediation`; connected by `AT` and `HAS_REMEDIATION` relationships; `_arity` and
+  `_depth` properties present on each.
+
+**Conventions:**
+- `_arity` on each graph-form node encodes the element count of the corresponding
+  nested pattern node, enabling the inverse to reconstruct arity.
+- `_depth` encodes nesting depth, enabling the inverse to reconstruct order.
+
+**Forward** (`DiagnosticPattern → DiagnosticGraph`): traverse the nested structure using
+`paraWithScope`, emit flat patterns with `_arity`/`_depth` properties, connect with typed
+relationships.
+
+**Inverse** (`DiagnosticGraph → DiagnosticPattern`): find all `Diagnostic` patterns via
+`allElements`, traverse edges using `containers`, reconstruct nesting from `_arity`/`_depth`.
+
+**Round-trip property**: for all `p` satisfying `kindPred DiagnosticPattern q p`,
+`(inverse q . forward q) p == p` structurally.
+
+### Relationship to GraphTransform
+
+`RepresentationMap` sits above `GraphTransform` (RFC-008) in the abstraction stack.
+The primitive operations from `GraphTransform` (`mapGraph`, `unfoldGraph`, `foldGraph`)
+and `Pattern.Core` (`paraWithScope`, `unfold`, `map`) are how you *build* the `forward`
+and `inverse` functions. `RepresentationMap` is how you *declare* that they are each
+other's inverse, name the kinds they operate between, and record the conventions.
+
+### Relationship to Pattern Equivalence
+
+Pattern equivalence (RFC draft) handles two gram expressions that are syntactically
+different but structurally identical — the same `Pattern Subject`, the same kind of
+shape. `RepresentationMap` handles two patterns of *different* kinds of shape that are
+informationally equivalent under declared conventions.
+
+### Implementation Sequence
+
+**Step 1 — Haskell prototype** (depends on RFC-006 and RFC-008)
+
+1. Define `PatternKind v` in `Pattern.Core`
+2. Define `RepresentationMap v` with `compose` in `Pattern.RepresentationMap`
+3. Implement `diagnosticMap` with declared kinds and conventions
+4. Write Hedgehog property tests: for all `p` satisfying `kindPred (domain m) q p`,
+   `roundTrip q m p` holds and `kindPred (codomain m) q (forward q p)` holds
+5. Write composition tests: `roundTrip` holds for composed maps
+
+**Step 2 — Rust port** (`pattern-rs`)
+
+```rust
+pub struct PatternKind<V: GraphValue> {
+    pub name:    String,
+    pub pred:    Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> bool>,
+    pub example: Pattern<V>,
+}
+
+pub struct RepresentationMap<V: GraphValue> {
+    pub name:        String,
+    pub domain:      PatternKind<V>,
+    pub codomain:    PatternKind<V>,
+    pub conventions: Vec<String>,
+    pub forward:     Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> Pattern<V>>,
+    pub inverse:     Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> Pattern<V>>,
+    pub round_trip:  Box<dyn Fn(&dyn ScopeQuery<V>, &Pattern<V>) -> bool>,
+}
+```
+
+**Step 3 — CLI surface** (`pato canonicalize`)
+
+```
+pato canonicalize [--map <n>] [--inverse] <files>...
+```
+
+Default map inferred from the document `kind` header. Scope constructed from the
+document being transformed.
+
+## Open Questions
+
+1. **Kind compatibility in `compose`** — `compose m1 m2` requires `codomain m1` and
+   `domain m2` to be compatible. Prototype uses a runtime check
+   (`kindName (codomain m1) == kindName (domain m2)`). Phantom type tags would make
+   it compile-time. Defer until the abstraction is stable.
+
+2. **RepresentationMap as a pattern** — Can a `RepresentationMap` itself be represented
+   as a `Pattern v`? If so, it could be serialized to gram, stored, and composed at
+   the data level. The `forward` and `inverse` *functions* cannot be serialized directly,
+   but the *description* (kinds, conventions, structural rules) may be pattern-representable.
+   Park until at least two concrete maps are implemented and their structure is well understood.
+
+## Alternatives
+
+**Ad-hoc one-off transformations** — the status quo before this RFC. Rejected because
+they accumulate technical debt: each transformation is a bespoke function with an
+implicit (undocumented) inverse, making them difficult to compose, test systematically,
+or port to other language targets.
+
+**Type-class-based shape constraints** — encoding kinds as type-level predicates. Rejected
+because kinds need to be computable at runtime (e.g. document-level schema validation
+via `pato validate`), and because the predicate-based approach aligns with the existing
+`GraphClassifier` design.

--- a/proposals/design/RFC-008-graph-transform.md
+++ b/proposals/design/RFC-008-graph-transform.md
@@ -1,0 +1,323 @@
+# RFC-008: GraphTransform — Construction, Transformation, and Pipeline
+
+**Status:** draft
+**Date:** 2026-02-19
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/graph-transform.md`](../graph-transform.md), [`proposals/pipeline-scenarios.md`](../pipeline-scenarios.md)
+**Depends on:** RFC-004 (GraphClassifier), RFC-005 (GraphQuery)
+**Followed by:** RFC-009 (GraphMutation), RFC-007 (RepresentationMap)
+**Related modules:** `Pattern.Core`, `Pattern.Graph`, `Pattern.Graph.Transform`
+
+## Summary
+
+Introduce `GraphView` as the universal graph-like interface and pipeline entry point,
+along with graph construction and transformation operations: `unfold`/`unfoldGraph` for
+construction from seed data, `mapGraph`/`filterGraph`/`foldGraph` for categorized
+transformation, `mapWithContext` for context-aware mapping, and `paraGraph` for
+structure-and-topology-aware folding. All transformation operations work over `GraphView`
+rather than any specific representation; `materialize` explicitly produces a concrete
+`PatternGraph v` on demand.
+
+## Motivation
+
+Every graph processing pipeline shares a common shape: impose a graph interpretation on
+source data, transform it, and optionally materialize a concrete representation. Whether
+the source is a CSV, a JSON document, a relational table, or an existing `PatternGraph`,
+the pipeline is identical from the graph interpretation onward. Without a universal
+graph-like interface, each source type requires bespoke ingestion, creating an impedance
+mismatch between "raw data processing" and "graph operations."
+
+`GraphView` eliminates this mismatch. A source is a graph from the moment a view is
+applied. This mirrors the GraphFrames model, where DataFrames *are* graphs when vertex
+and edge columns are designated.
+
+Three motivating pipeline scenarios ground the design:
+1. **ETL from structured data** — CSV/JSON rows become nodes; shared field values become
+   relationships or shared nodes.
+2. **Graph-to-graph transformation** — normalize labels, enrich nodes with computed
+   properties, project a subgraph.
+3. **Knowledge graph construction** — multi-stage pipeline from raw documents through
+   chunking, NER, and relationship extraction.
+
+All three follow the same canonical shape:
+
+```
+source data
+  → GraphView  (impose a graph interpretation)
+  → [GraphView → GraphView transformations]
+  → materialize → PatternGraph  (when concrete storage is required)
+```
+
+## Design
+
+### `GraphView` — Universal Graph-Like Interface
+
+`GraphView` pairs a `GraphQuery v` with classified element enumeration:
+
+```haskell
+data GraphView extra v = GraphView
+  { viewQuery    :: GraphQuery v
+  , viewElements :: [(GraphClass extra, Pattern v)]
+  }
+```
+
+`GraphQuery v` provides traversal (nodes, relationships, containers, incident rels).
+`viewElements` provides the classified enumeration needed by categorized operations.
+Together they express everything a transformation needs to know about the source graph.
+
+`GraphView` is constructable from any graph-like thing:
+
+```haskell
+fromPatternGraph :: GraphClassifier extra v -> PatternGraph v   -> GraphView extra v
+fromGraphLens    :: GraphClassifier extra v -> GraphLens v      -> GraphView extra v
+-- fromCSV, fromJSON live in adapter modules; they target GraphView
+```
+
+### `materialize` — Explicit Boundary
+
+`materialize` is the explicit step that turns a `GraphView` into a `PatternGraph`:
+
+```haskell
+materialize :: GraphClassifier extra v
+            -> ReconciliationPolicy (MergeStrategy v)
+            -> GraphView extra v
+            -> PatternGraph v
+```
+
+Transformations operate lazily over `GraphView`. Materialization is deferred until the
+caller explicitly requests it, enabling `GraphView → GraphView` pipelines without
+copying data at each step.
+
+**The canonical pipeline shape:**
+
+```haskell
+pipeline :: CSV -> PatternGraph Subject
+pipeline csv =
+  materialize canonicalClassifier LastWriteWins  -- GraphView → PatternGraph
+  . mapWithContext enrich                         -- GraphView → GraphView
+  . filterGraph isRelevant dissolve              -- GraphView → GraphView
+  . fromCSV canonicalClassifier                  -- CSV → GraphView
+  $ csv
+```
+
+### Construction: `unfold` and `unfoldGraph`
+
+`unfold` is the anamorphism dual to `para` (already implemented). It builds a `Pattern v`
+from a seed value:
+
+```haskell
+-- Pattern.Core
+unfold :: (a -> (v, [a])) -> a -> Pattern v
+```
+
+`unfoldGraph` maps a collection of seeds through an expansion function and batch-merges:
+
+```haskell
+-- Pattern.Graph.Transform
+unfoldGraph :: GraphClassifier extra v
+            -> ReconciliationPolicy (MergeStrategy v)
+            -> (a -> [Pattern v])
+            -> [a]
+            -> PatternGraph v
+```
+
+**ETL example** — each CSV row expands to a person node and a department node:
+
+```haskell
+rowToPatterns :: Row -> [Pattern Subject]
+rowToPatterns row = [ personNode row, departmentNode row, worksInRel row ]
+
+graph = unfoldGraph canonicalClassifier LastWriteWins rowToPatterns rows
+```
+
+Shared elements (the same department appearing in many rows) are reconciled
+automatically. `unfoldGraph` is `fromPatterns` generalized to arbitrary seed types.
+
+**Hierarchy construction** — building a document hierarchy uses the recursive form:
+
+```haskell
+docExpand :: DocNode -> (Subject, [DocNode])
+docExpand node = (nodeSubject node, children node)
+
+chunkHierarchy = unfold docExpand documentRoot
+```
+
+### Categorized Transformation: `mapGraph`, `filterGraph`, `foldGraph`
+
+All operate on `GraphView extra v` with `GraphClass` information available and produce
+a new `GraphView extra v`, enabling composition before materialization.
+
+#### `mapGraph`
+
+```haskell
+mapGraph :: GraphClassifier extra v
+         -> (Pattern v -> Pattern v)  -- nodes
+         -> (Pattern v -> Pattern v)  -- relationships
+         -> (Pattern v -> Pattern v)  -- walks
+         -> (Pattern v -> Pattern v)  -- annotations
+         -> (Pattern v -> Pattern v)  -- other
+         -> GraphView extra v -> GraphView extra v
+
+mapAllGraph :: (Pattern v -> Pattern v) -> GraphView extra v -> GraphView extra v
+```
+
+#### `filterGraph`
+
+```haskell
+filterGraph :: GraphClassifier extra v
+            -> (GraphClass extra -> Pattern v -> Bool)
+            -> Substitution v
+            -> GraphView extra v -> GraphView extra v
+```
+
+The predicate receives both the element's class and the element itself. `Substitution`
+determines what happens to containers of filtered-out elements (see RFC-009).
+
+#### `foldGraph`
+
+```haskell
+foldGraph :: Monoid m
+          => (GraphClass extra -> Pattern v -> m)
+          -> GraphView extra v -> m
+```
+
+**Example** — count elements by category:
+
+```haskell
+countByClass :: GraphView extra v -> Map (GraphClass extra) Int
+countByClass = foldGraph (\cls _ -> Map.singleton cls 1)
+```
+
+### Context-Aware Mapping: `mapWithContext`
+
+Map over elements where each mapping function has access to the full graph context:
+
+```haskell
+mapWithContext :: GraphClassifier extra v
+               -> (GraphQuery v -> Pattern v -> Pattern v)
+               -> GraphView extra v -> GraphView extra v
+```
+
+The `GraphQuery` is derived from the *original* view — snapshot semantics. All elements
+are transformed against the same source graph, not against incrementally modified results.
+(Incremental semantics produce non-deterministic outputs depending on map iteration order,
+which is a correctness problem, not just a predictability concern.)
+
+**Example** — enrich each node with a count of its annotations:
+
+```haskell
+enrichWithAnnotationCount :: GraphView () Subject -> GraphView () Subject
+enrichWithAnnotationCount =
+  mapWithContext canonicalClassifier enrich
+  where
+    enrich q node =
+      let count = length (queryAnnotationsOf canonicalClassifier q node)
+      in  setAnnotationCount count node
+```
+
+### `paraGraph` — Structure-and-Topology-Aware Folding
+
+`paraGraph` extends `para` to graph topology: each element's result depends on both its
+structural decomposition and computed results from graph neighbors.
+
+```haskell
+paraGraph :: (GraphQuery v -> Pattern v -> [r] -> r)
+          -> GraphView extra v
+          -> Map (Id v) r
+```
+
+Each element receives the `GraphQuery` (full context), the element itself, and the
+recursively computed results from its structural children. This is the foundation for
+iterative message-passing algorithms — the Pregel / GraphFrames `AggregateMessages`
+analogue.
+
+For general graphs (with cycles), fixpoint iteration is provided:
+
+```haskell
+paraGraphFixed :: (r -> r -> Bool)         -- convergence predicate
+               -> (GraphQuery v -> Pattern v -> [r] -> r)
+               -> r                         -- initial value
+               -> GraphView extra v
+               -> Map (Id v) r
+```
+
+A user-supplied convergence predicate (not `Eq r`) is required because floating-point
+values — the common case for centrality and propagation — rarely converge to strict
+equality. Callers supply `\old new -> abs (old - new) < epsilon` for floats, `(==)` for
+integral types.
+
+### Deferred Operations
+
+**`mergeByPredicate`** — fuzzy identity matching for coreference resolution. Required
+for knowledge graph quality (reconciling "Apple Inc." and "Apple"). Deferred because:
+- Mutation-adjacent (semantically an insertion operation with a search step prepended)
+- Cross-cutting (requires both `GraphQuery` and `GraphMutation`)
+- Unresolved `MultiMatchPolicy` question and O(n) performance implications
+
+**`expandNode`** and **`rewireRelationship`** — higher-order graph editing. Deferred
+pending a dedicated higher-order graph editing proposal.
+
+### Module Placement
+
+**Recommendation: Option C**
+- `Pattern.Core.unfold` alongside its categorical dual `para`
+- `GraphView` and `materialize` in `Pattern.Graph` alongside `GraphLens`, `GraphQuery`
+- Everything else in `Pattern.Graph.Transform`
+
+`GraphView` belongs near `GraphLens` and `GraphQuery` because it *is* the abstraction
+that unifies them.
+
+### What Changes in pattern-hs
+
+| Component | Action | Notes |
+|---|---|---|
+| `Pattern.Core.unfold` | **New** | Anamorphism dual to `para` |
+| `Pattern.Graph.GraphView` | **New** | Universal graph-like interface |
+| `Pattern.Graph.materialize` | **New** | `GraphView → PatternGraph`; explicit materialization |
+| `Pattern.Graph.fromPatternGraph` | **Update** | Returns `GraphView` in addition to `GraphQuery` |
+| `Pattern.Graph.fromGraphLens` | **Update** | Returns `GraphView` in addition to `GraphQuery` |
+| `Pattern.Graph.Transform` | **New module** | All graph-level transformation functions |
+| `Pattern.Graph.Transform.unfoldGraph` | **New** | Seed-based graph construction |
+| `Pattern.Graph.Transform.mapGraph` | **New** | Categorized map over `GraphView` |
+| `Pattern.Graph.Transform.mapAllGraph` | **New** | Uniform map over all categories |
+| `Pattern.Graph.Transform.filterGraph` | **New** | Predicate filter with `Substitution` |
+| `Pattern.Graph.Transform.foldGraph` | **New** | Categorized fold |
+| `Pattern.Graph.Transform.mapWithContext` | **New** | Context-aware map via `GraphQuery` |
+| `Pattern.Graph.Transform.paraGraph` | **New** | Structure-and-topology-aware fold |
+| `Pattern.Graph.Transform.paraGraphFixed` | **New** | Fixpoint variant for iterative algorithms |
+
+### Implementation Order
+
+1. `GraphView` and `materialize` in `Pattern.Graph`
+2. `unfold` in `Pattern.Core`
+3. `unfoldGraph`, `mapGraph`, `mapAllGraph`, `foldGraph` (no `GraphQuery` dependency)
+4. `mapWithContext`, `filterGraph` (require `GraphQuery` and `Substitution`)
+5. `paraGraph`, `paraGraphFixed` (require `GraphQuery`; need processing order strategy)
+
+`Substitution v` (used by `filterGraph`) must be defined before `GraphTransform` is
+implemented. It can be extracted to a shared types module (`Pattern.Graph.Types`) ahead
+of the full RFC-009 (GraphMutation) implementation.
+
+## Open Questions
+
+1. **`paraGraph` processing order for DAGs** — the caller-supplied ordering variant
+   (topological sort) is simpler but puts the burden on the user. The recommended
+   default for cyclic graphs is `paraGraphFixed`.
+
+2. **`filterGraph` and walk coherence** — filtering out a relationship that is part of
+   a walk leaves the walk with a gap. `NoSubstitution` default produces a broken walk
+   in `pgOther`. Recommend explicit `Substitution` for now.
+
+## Alternatives
+
+**Special-casing source types** — treating CSV, JSON, and PatternGraph as fundamentally
+different ingestion paths was the status quo approach. `GraphView` eliminates this by
+making the pipeline source-agnostic from the first step.
+
+**Eager materialization** — materializing a `PatternGraph` at each transformation step
+was rejected. Lazy composition over `GraphView` avoids unnecessary copies and makes
+pipelines composable as pure functions.
+
+**`paraMap` / `paraWith`** — these were considered as intermediate operations but deferred;
+`paraGraph` covers the graph-level use cases.

--- a/proposals/design/RFC-009-graph-mutation.md
+++ b/proposals/design/RFC-009-graph-mutation.md
@@ -1,0 +1,240 @@
+# RFC-009: GraphMutation — Coherent In-Memory Graph Mutations
+
+**Status:** draft
+**Date:** 2026-02-19
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/graph-mutation.md`](../graph-mutation.md)
+**Depends on:** RFC-004 (GraphClassifier), RFC-005 (GraphQuery), RFC-008 (GraphTransform)
+**Related modules:** `Pattern.Graph`, `Pattern.PatternGraph`
+
+## Summary
+
+Introduce `GraphMutation v` as a record-of-functions providing merge, update, and delete
+operations over a graph representation. `mergeElement` is the single insertion entry
+point — total, classifier-driven, recursively decomposing. `updateValue` is partial,
+failing only when the element does not exist. `deleteElement` takes a `Substitution v`
+that controls what happens to containers when an element is removed. `GraphMutation` is
+the complement to `GraphQuery` (RFC-005): together they form the complete read/write
+interface over a graph.
+
+## Motivation
+
+A `PatternGraph` has multi-element structural invariants: a relationship must have two
+endpoint nodes; a walk's constituent relationships must exist as independent entries; an
+annotation's inner element must exist.
+
+**Insertion invariants maintain themselves**: `mergeElement`'s recursive decomposition
+ensures coherence — merging a relationship auto-merges its endpoint nodes; merging a walk
+auto-merges its constituent relationships and their nodes. The graph is always coherent
+after a merge because the operation ensures its own preconditions.
+
+**Deletion invariants cannot maintain themselves without declaring intent**: when an
+element is removed, any container that referenced it drops one arity and shifts
+classification. The caller must declare via `Substitution v` what should happen: allow
+re-classification, replace the removed element, or cascade the deletion.
+
+**Value updates do not affect structure**: the canonical classifier operates on `elements`
+not `value`, so updating a value never shifts an element's classification.
+
+`GraphMutation` is a record-of-functions (consistent with `GraphClassifier` and
+`GraphQuery`) because:
+- **Portable** — maps to interfaces (Java), function pointer structs (Rust/C), plain
+  objects (TypeScript) without typeclass machinery
+- **Composable** — wrappable with logging, validation, or audit trail functions
+- **Future-compatible** — a database-backed graph produces a `GraphMutation v` that
+  closes over a connection; the surface is identical to in-memory
+
+## Design
+
+### Error Type
+
+```haskell
+data GraphMutationError v = ElementNotFound (Id v)
+```
+
+One case. `deleteElement` cannot fail due to containers — `Substitution v` declares
+how containers are handled. `updateValue` cannot fail due to classification — value
+updates do not affect structure. The only genuine failure is acting on a non-existent element.
+
+### `GraphMutation` — the Interface
+
+```haskell
+data GraphMutation v = GraphMutation
+  { mergeElement   :: ReconciliationPolicy (MergeStrategy v) -> Pattern v
+                   -> PatternGraph v -> PatternGraph v
+
+  , updateValue    :: Id v -> v -> PatternGraph v
+                   -> Either (GraphMutationError v) (PatternGraph v)
+
+  , deleteElement  :: Id v -> Substitution v -> PatternGraph v
+                   -> Either (GraphMutationError v) (PatternGraph v)
+
+  , updateValues   :: [(Id v, v)] -> PatternGraph v
+                   -> ([GraphMutationError v], PatternGraph v)
+
+  , deleteElements :: [Id v] -> Substitution v -> PatternGraph v
+                   -> ([GraphMutationError v], PatternGraph v)
+  }
+```
+
+`mergeElement` is total. `updateValue` and `deleteElement` return `Either`, failing only
+with `ElementNotFound`. `updateValues` and `deleteElements` accumulate errors rather than
+short-circuiting — the correct behavior for ETL pipelines where missing elements should
+be logged and skipped, not abort the operation.
+
+### `Substitution` — Deletion Policy for Containers
+
+```haskell
+data Substitution v
+  = NoSubstitution                             -- remove; containers drop arity and re-classify
+  | SubstituteWith (Pattern v)                 -- replace with a specific element in all containers
+  | SubstituteBy   (Pattern v -> [Pattern v])  -- derive zero or more replacements per container
+  | CascadeDelete                              -- delete all containers recursively, then element
+```
+
+`SubstituteBy` returns `[Pattern v]`:
+- `[]` — dissolve the container
+- `[p]` — replace the container with `p`
+- `[p, q, ...]` — split the container into multiple patterns, each re-merged independently
+
+`SubstituteWith p` is exactly `SubstituteBy (const [p])`.
+
+**`NoSubstitution`** (default) removes the element from each container's `elements` list
+and re-merges the modified container. Re-classification follows: a relationship losing a
+node becomes an annotation; an annotation losing its inner element becomes a node.
+
+**`CascadeDelete`** is the nuclear option: deletes all containers recursively first, then
+the element itself.
+
+**Guarded delete** is a call-site idiom using `queryContainers` (RFC-005), not a
+`Substitution` variant:
+
+```haskell
+let containers = queryContainers gq element
+in if null containers
+   then deleteElement mut elementId NoSubstitution graph
+   else -- inspect containers, choose Substitution, or abort
+```
+
+### Substitution Combinators
+
+```haskell
+dissolve   :: Substitution v
+dissolve   = SubstituteBy (const [])
+
+reconnect  :: Pattern v -> Substitution v
+reconnect p = SubstituteWith p
+
+-- Structural helper: partition a walk's remaining elements into contiguous
+-- chains of valid relationships after the deleted element has been removed.
+partitionChains :: GraphClassifier extra v -> Pattern v -> [[Pattern v]]
+```
+
+Fragment identity generation is always the caller's responsibility:
+
+```haskell
+let splitRoute container =
+      let chains = partitionChains classifier container
+      in  zipWith (\v chain -> Pattern v chain) [routeAValue, routeBValue] chains
+deleteElement mut hospitalId (SubstituteBy splitRoute) graph
+```
+
+### `mergeElement` Behaviour
+
+`mergeElement` classifies the incoming pattern and dispatches:
+
+- **`GNode`** — stored in `pgNodes`. If identity exists, `ReconciliationPolicy` applies.
+- **`GRelationship`** — endpoint nodes are recursively merged first, then stored in
+  `pgRelationships`. Always coherent.
+- **`GWalk`** — constituent relationships recursively merged (which merges their nodes),
+  then stored in `pgWalks`.
+- **`GAnnotation`** — inner element recursively merged, then stored in `pgAnnotations`.
+- **`GOther extra`** — stored in `pgOther`. No coherence requirement.
+
+### `updateValue` Behaviour
+
+Looks up element by identity; fails with `ElementNotFound` if absent; applies new value
+in place within the appropriate map. Classification is unaffected.
+
+### Constructing a `GraphMutation`
+
+```haskell
+canonicalMutation :: (GraphValue v, Eq v)
+                  => GraphClassifier extra v
+                  -> GraphView extra v    -- provides queryContainers for deleteElement
+                  -> GraphMutation v
+
+defaultMutation :: (GraphValue v, Eq v) => PatternGraph v -> GraphMutation v
+defaultMutation pg =
+  canonicalMutation canonicalClassifier (fromPatternGraph canonicalClassifier pg)
+```
+
+`GraphView` (RFC-008) must be settled before `canonicalMutation` is finalized, since
+the mutation layer needs the full classified element set to know which map an element
+lives in.
+
+### Composability
+
+```haskell
+auditMutation  :: (String -> IO ()) -> GraphMutation v -> GraphMutation v
+dryRunMutation :: GraphMutation v -> GraphMutation v
+```
+
+Wrappers compose via the same `GraphMutation v -> GraphMutation v` pattern established by
+RFC-005 for `GraphQuery`.
+
+### Structural Update Pattern
+
+Structural updates (rewiring a relationship) are expressed as delete-then-merge:
+
+```haskell
+rewire :: GraphMutation v -> Id v -> Pattern v -> PatternGraph v
+       -> Either (GraphMutationError v) (PatternGraph v)
+rewire mut oldRelId newRelPattern graph = do
+  graph' <- deleteElement mut oldRelId NoSubstitution graph
+  Right (mergeElement mut LastWriteWins newRelPattern graph')
+```
+
+### Relationship to Existing Code
+
+`PatternGraph.merge` and `PatternGraph.fromPatterns` are retained as backward-compatible
+wrappers that delegate to `mergeElement` with `LastWriteWins`.
+
+### What Changes in pattern-hs
+
+| Component | Action | Notes |
+|---|---|---|
+| `Pattern.Graph.GraphMutation` | **New** | Five-function record including bulk variants |
+| `Pattern.Graph.GraphMutationError` | **New** | `ElementNotFound` |
+| `Pattern.Graph.Substitution` | **New** | Four cases including `SubstituteBy` |
+| `Pattern.Graph.dissolve` | **New** | `SubstituteBy (const [])` |
+| `Pattern.Graph.reconnect` | **New** | Alias for `SubstituteWith` |
+| `Pattern.Graph.partitionChains` | **New** | Structural helper for walk splitting |
+| `Pattern.Graph.canonicalMutation` | **New** | Canonical in-memory constructor |
+| `Pattern.Graph.defaultMutation` | **New** | Convenience constructor from `PatternGraph` |
+| `Pattern.PatternGraph.merge` | **Retain as wrapper** | Delegates to `mergeElement` |
+| `Pattern.PatternGraph.fromPatterns` | **Retain as wrapper** | Delegates to `mergeElement` fold |
+
+## Open Questions
+
+1. **`DetachDelete` semantics for walks** — removing a relationship from a walk may
+   leave the walk structurally invalid (broken chain). Should `DetachDelete` on a
+   relationship that is part of a walk dissolve the walk entirely, split it into two
+   shorter walks, or leave the gap and route it to `pgOther`? Requires a decision about
+   walk identity after structural modification.
+
+## Alternatives
+
+**Integrated read/write type** — combining `GraphQuery` and `GraphMutation` into a single
+`GraphStore` type was rejected. Keeping them separate preserves the composability story
+for each independently and makes it possible to construct read-only handles (a
+`GraphQuery v` without a corresponding `GraphMutation v`).
+
+**`GuardedDelete` as a `Substitution` variant** — rejected because the decision logic
+belongs at the call site where the intent lives, not inside the mutation layer.
+
+**Dedicated structural constructors** — `rewireRelationship`, `expandNode` as first-class
+operations were deferred. Delete-then-merge keeps `GraphMutation` small and intent
+explicit; dedicated structural operations belong in a future higher-order graph editing
+proposal.

--- a/proposals/design/RFC-010-pattern-reconciliation.md
+++ b/proposals/design/RFC-010-pattern-reconciliation.md
@@ -1,6 +1,6 @@
 # RFC-010: Pattern Reconciliation
 
-**Status:** draft
+**Status:** accepted
 **Date:** 2026-01-15
 **Authors:** @akollegger
 **Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
@@ -9,7 +9,7 @@
 
 ## Summary
 
-Add a `reconcile` operation to `Pattern.Reconcile` that normalizes `Pattern Subject`
+`Pattern.Reconcile` provides a `reconcile` operation that normalizes `Pattern Subject`
 values by resolving duplicate identities and completing partial references. This
 transforms a potentially inconsistent pattern (from parsing, streaming, or merging) into
 a coherent one where each identity appears exactly once with fully resolved content.
@@ -36,17 +36,18 @@ This situation arises naturally when:
 3. **Merging patterns** — combining patterns from different sources
 4. **References** — an atomic pattern may reference a fuller definition elsewhere
 
-Currently there is no mechanism to detect duplicate identities, resolve which definition
-is authoritative, or complete partial references.
+Without reconciliation, there is no mechanism to detect duplicate identities, resolve
+which definition is authoritative, or complete partial references.
 
 ## Design
 
 ### Module Placement
 
-`Pattern.Reconcile` — a new module. Rationale: `Pattern.Core` is generic over any value
-type `v`; reconciliation is specific to `Pattern Subject` (requires identity). Keeping
-them separate allows reconciliation to depend on both `Pattern.Core` and `Subject.Core`
-without pulling Subject-specific logic into the generic core.
+`Pattern.Reconcile` — a separate module from `Pattern.Core`. Rationale: `Pattern.Core`
+is generic over any value type `v`; reconciliation is specific to `Pattern Subject`
+(requires identity). Keeping them separate allows reconciliation to depend on both
+`Pattern.Core` and `Subject.Core` without pulling Subject-specific logic into the
+generic core.
 
 ### Core Types
 

--- a/proposals/design/RFC-010-pattern-reconciliation.md
+++ b/proposals/design/RFC-010-pattern-reconciliation.md
@@ -1,0 +1,245 @@
+# RFC-010: Pattern Reconciliation
+
+**Status:** draft
+**Date:** 2026-01-15
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** [`proposals/pattern-reconciliation.md`](../pattern-reconciliation.md)
+**Related modules:** `Pattern.Core`, `Pattern.Reconcile`, `Subject.Core`
+
+## Summary
+
+Add a `reconcile` operation to `Pattern.Reconcile` that normalizes `Pattern Subject`
+values by resolving duplicate identities and completing partial references. This
+transforms a potentially inconsistent pattern (from parsing, streaming, or merging) into
+a coherent one where each identity appears exactly once with fully resolved content.
+The operation is identity-aware normalization: it treats `Pattern Subject` as a
+collection of entities that should each appear once, not as a pure tree structure.
+
+## Motivation
+
+`Pattern Subject` is a recursive container where `Subject` values carry identity. Nothing
+prevents the same identity from appearing multiple times with potentially different content:
+
+```haskell
+example :: Pattern Subject
+example = pattern rootSubject
+  [ point aliceV1           -- alice with name="Alice"
+  , point bobSubject
+  , point aliceV2           -- alice with name="Alice Smith" (updated?)
+  ]
+```
+
+This situation arises naturally when:
+1. **Parsing gram notation** — sequential form allows the same ID to appear multiple times
+2. **Streaming patterns** — incremental updates arrive as new patterns with same IDs
+3. **Merging patterns** — combining patterns from different sources
+4. **References** — an atomic pattern may reference a fuller definition elsewhere
+
+Currently there is no mechanism to detect duplicate identities, resolve which definition
+is authoritative, or complete partial references.
+
+## Design
+
+### Module Placement
+
+`Pattern.Reconcile` — a new module. Rationale: `Pattern.Core` is generic over any value
+type `v`; reconciliation is specific to `Pattern Subject` (requires identity). Keeping
+them separate allows reconciliation to depend on both `Pattern.Core` and `Subject.Core`
+without pulling Subject-specific logic into the generic core.
+
+### Core Types
+
+```haskell
+data ReconciliationPolicy
+  = LastWriteWins       -- later occurrence overwrites earlier
+  | FirstWriteWins      -- first occurrence is kept, later ignored
+  | Merge MergeStrategy -- merge content from all occurrences
+  | Strict              -- fail on any duplicate with different content
+
+data MergeStrategy = MergeStrategy
+  { labelMerge    :: LabelMerge
+  , propertyMerge :: PropertyMerge
+  , elementMerge  :: ElementMerge
+  }
+
+data LabelMerge    = UnionLabels | IntersectLabels | ReplaceLabels
+data PropertyMerge = ReplaceProperties | ShallowMerge | DeepMerge
+data ElementMerge  = ReplaceElements | AppendElements | UnionElements
+
+defaultMergeStrategy :: MergeStrategy
+defaultMergeStrategy = MergeStrategy UnionLabels ShallowMerge UnionElements
+```
+
+### Error and Report Types
+
+```haskell
+data Conflict = Conflict
+  { conflictId        :: Symbol
+  , conflictExisting  :: Subject
+  , conflictIncoming  :: Subject
+  , conflictLocations :: [Path]
+  }
+
+type Path = [Int]  -- indices from root
+
+data ReconcileError = ReconcileError
+  { errorMessage   :: String
+  , errorConflicts :: [Conflict]
+  }
+
+data ReconcileReport = ReconcileReport
+  { reportDuplicatesFound    :: Int
+  , reportReferencesResolved :: Int
+  , reportMergesPerformed    :: Int
+  , reportSubjectCounts      :: Map Symbol Int
+  }
+```
+
+### Core Functions
+
+```haskell
+reconcile
+  :: ReconciliationPolicy
+  -> Pattern Subject
+  -> Either ReconcileError (Pattern Subject)
+
+reconcileWithReport
+  :: ReconciliationPolicy
+  -> Pattern Subject
+  -> (Either ReconcileError (Pattern Subject), ReconcileReport)
+
+needsReconciliation :: Pattern Subject -> Bool
+findConflicts       :: Pattern Subject -> [Conflict]
+```
+
+### Reference Detection
+
+References are detected structurally, not syntactically. A pattern is considered a
+reference if it is atomic (no elements) and the same identity appears elsewhere with
+more content (elements, more labels, more properties):
+
+```haskell
+isRefinementOf :: Subject -> Subject -> Bool
+isRefinementOf full partial =
+  identity full == identity partial
+  && labels partial `Set.isSubsetOf` labels full
+  && all (\(k,v) -> Map.lookup k (properties full) == Just v)
+         (Map.toList (properties partial))
+
+isReference :: Pattern Subject -> Map Symbol (Pattern Subject) -> Bool
+isReference (Pattern subj []) known =
+  case Map.lookup (identity subj) known of
+    Just fuller -> not (null (elements fuller))
+                   || isRefinementOf (value fuller) subj
+    Nothing -> False
+isReference _ _ = False
+```
+
+### Algorithm
+
+```haskell
+reconcile policy pat = do
+  -- Phase 1: collect all subjects by identity
+  let occurrences = collectByIdentity pat  -- Map Symbol [(Subject, Path)]
+
+  -- Phase 2: reconcile each identity to a single canonical Subject
+  canonical <- reconcileOccurrences policy occurrences  -- Map Symbol Subject
+
+  -- Phase 3: rebuild pattern, replacing duplicates/references with canonical
+  rebuildPattern canonical pat
+```
+
+`collectByIdentity` is a recursive traversal producing a map from identity to all
+(subject, path) pairs. `reconcileOccurrences` applies the chosen policy. `rebuildPattern`
+walks the pattern with a `Set` of already-emitted identities, emitting each identity
+exactly once.
+
+**Complexity**: O(n) time and O(k) space, where n is total pattern nodes and k is unique
+identities.
+
+### Usage Examples
+
+```haskell
+-- Normalize after parsing (duplicates expected)
+case reconcile LastWriteWins parsed of
+  Right normalized -> usePattern normalized
+  Left err         -> handleError err
+
+-- Validate coherence
+case reconcile Strict parsed of
+  Right _ -> putStrLn "Pattern is already coherent"
+  Left err -> putStrLn $ "Conflicts: " ++ show (errorConflicts err)
+
+-- Merge patterns from different sources
+let combined = pattern rootSubject [patternA, patternB, patternC]
+case reconcile (Merge defaultMergeStrategy) combined of
+  Right unified -> savePattern unified
+  Left err      -> handleConflicts err
+
+-- Get diagnostic report
+let (result, report) = reconcileWithReport (Merge defaultMergeStrategy) parsed
+putStrLn $ "Resolved " ++ show (reportDuplicatesFound report) ++ " duplicates"
+```
+
+### Relationship to Existing Functions
+
+| Existing | Purpose | Reconcile Relationship |
+|---|---|---|
+| `fmap` | Transform values | Reconcile transforms structure |
+| `para` | Structure-aware fold | Reconcile uses similar traversal internally |
+| `filterPatterns` | Find matching patterns | `findConflicts` is identity-focused |
+
+Reconciliation provides what none of the existing functions do: **identity-aware
+normalization**. It treats `Pattern Subject` as a collection of entities that should each
+appear once, rather than as a pure tree structure.
+
+### Edge Cases
+
+- **Self-referential**: track seen identities during rebuild; emit each only once
+- **Orphan references**: references to undefined identities pass through as-is
+  (keep atomic pattern)
+- **Circular references**: track visited during rebuild; break cycles
+- **Empty pattern**: return unchanged
+
+### Testing Requirements
+
+1. Property tests:
+   - `reconcile p` is idempotent: `reconcile (reconcile p) == reconcile p`
+   - `reconcile` preserves all unique identities
+   - `Strict` mode detects all and only actual conflicts
+2. Unit tests: each policy, each merge strategy, reference resolution, edge cases
+3. Equivalence tests: `reconcile . parse . serialize == reconcile` for gram round-trips
+
+### Compatibility
+
+No breaking changes. New module `Pattern.Reconcile`. Existing code continues to work
+unchanged. Users opt-in by importing and calling `reconcile`.
+
+## Open Questions
+
+1. **Orphan references**: should orphan references (references to undefined identities)
+   pass through silently or be configurable via an `OrphanPolicy`?
+
+2. **Element order after reconciliation**: preserve order of first occurrence and dedupe
+   later occurrences, or offer an ordering option?
+
+3. **Reconcilable typeclass**: a `class HasIdentity v where identity :: v -> Symbol`
+   would generalize reconciliation beyond `Subject`. Current proposal keeps it
+   `Subject`-specific; the case for generalization is weak until a second value type
+   with identity emerges.
+
+4. **Streaming API**: an incremental form
+   `reconcileIncremental :: Pattern Subject -> Pattern Subject -> Pattern Subject`
+   would support append-only update patterns without full reprocessing. Deferred.
+
+## Alternatives
+
+**Eager reconciliation during parsing** — reconciling at parse time rather than as a
+post-processing step. Rejected because it couples parsing to reconciliation policy,
+making it harder to test them independently and preventing use of the same parser for
+round-trip validation (where preserving duplicates may be intentional).
+
+**Reserved-property approach** — encoding reconciliation metadata as reserved `Subject`
+properties. Rejected because it conflates user-meaningful properties with library
+bookkeeping and leaks into serialization.

--- a/proposals/design/SEMANTICS.md
+++ b/proposals/design/SEMANTICS.md
@@ -1,5 +1,10 @@
 # Gram Pattern Semantics
 
+> **Superseded by [RFC-003: Gram Notation Semantics](RFC-003-gram-notation-semantics.md)**
+> 
+> This document is retained for historical reference. RFC-003 merges this document with
+> `EXTENDED-SEMANTICS.md`, removes duplication, and reorganises into the standard RFC format.
+
 **Status**: ✅ Implemented  
 **Implementation**: Gram serialization and parsing  
 **Reference**: See `docs/reference/semantics/gram-semantics.md` for current specification

--- a/proposals/design/pattern-category.md
+++ b/proposals/design/pattern-category.md
@@ -4,8 +4,9 @@
 > 
 > This document is retained for historical reference. The category-theoretic perspective
 > (CategoryLens, morphism equivalence, value magma) is incorporated into RFC-002.
-> The Q&A fragment at the start of this document was an authoring artifact and is
-> addressed in RFC-002's "Alternatives" section.
+> The Q&A fragment at the start of this document was an authoring artifact; the
+> underlying question (morphism equivalence under different equivalence relations)
+> is discussed in RFC-002's "Category-Theoretic Perspective" section.
 
 **Status**: 📝 Design Only  
 **Implementation**: Not currently planned. This document explores category-theoretic foundations.

--- a/proposals/design/pattern-category.md
+++ b/proposals/design/pattern-category.md
@@ -1,7 +1,19 @@
+# Inducing Categories from Patterns (Historical Notes)
+
+> **Superseded by [RFC-002: Pattern as Container and Graph Substrate](RFC-002-pattern-container-substrate.md)**
+> 
+> This document is retained for historical reference. The category-theoretic perspective
+> (CategoryLens, morphism equivalence, value magma) is incorporated into RFC-002.
+> The Q&A fragment at the start of this document was an authoring artifact and is
+> addressed in RFC-002's "Alternatives" section.
+
 **Status**: 📝 Design Only  
 **Implementation**: Not currently planned. This document explores category-theoretic foundations.
 
-If so, are composed patterns with the same start and end leaf  equivalent, or congruent?
+*Note: The following was a Q&A discussion about morphism equivalence that was accidentally
+included at the top of this file:*
+
+If so, are composed patterns with the same start and end leaf equivalent, or congruent?
 
 **Compositions via CategoryLens:**
 

--- a/proposals/graph-classifier.md
+++ b/proposals/graph-classifier.md
@@ -1,5 +1,7 @@
 # Proposal: GraphClassifier — A Unified, Extensible Graph View for pattern-hs
 
+> **Superseded by [RFC-004: GraphClassifier](design/RFC-004-graph-classifier.md)**
+
 **Status**: 📝 Design Only  
 **Date**: 2026-02-19  
 **Relates to**: Feature 23 (GraphLens), Feature 33 (PatternGraph)  

--- a/proposals/graph-mutation.md
+++ b/proposals/graph-mutation.md
@@ -1,5 +1,7 @@
 # Proposal: GraphMutation — Coherent In-Memory Graph Mutations
 
+> **Superseded by [RFC-009: GraphMutation](design/RFC-009-graph-mutation.md)**
+
 **Status**: 📝 Design Only  
 **Date**: 2026-02-19  
 **Depends on**: GraphClassifier proposal, GraphQuery proposal, GraphTransform proposal  

--- a/proposals/graph-query.md
+++ b/proposals/graph-query.md
@@ -1,5 +1,7 @@
 # Proposal: GraphQuery — A Portable, Composable Graph Query Interface
 
+> **Superseded by [RFC-005: GraphQuery](design/RFC-005-graph-query.md)**
+
 **Status**: 📝 Design Only  
 **Date**: 2026-02-19  
 **Depends on**: GraphClassifier proposal  

--- a/proposals/graph-transform.md
+++ b/proposals/graph-transform.md
@@ -1,5 +1,8 @@
 # Proposal: GraphTransform — GraphView, Construction, Transformation, and Context-Aware Mapping
 
+> **Superseded by [RFC-008: GraphTransform](design/RFC-008-graph-transform.md)**
+> (consolidates this document with `pipeline-scenarios.md`)
+
 **Status**: 📝 Design Only  
 **Date**: 2026-02-19  
 **Depends on**: GraphClassifier proposal, GraphQuery proposal  

--- a/proposals/pattern-equivalence.md
+++ b/proposals/pattern-equivalence.md
@@ -1,5 +1,11 @@
 # Proposal: Pattern Equivalence for pattern-hs
 
+> **Pre-RFC stub** — This document contains motivating examples but lacks a full design.
+> It should be developed into a complete RFC before implementation. The core problem
+> (resolving ambiguity between gram path notation and pattern notation for the same
+> `Pattern Subject`) is distinct from RFC-010 (Pattern Reconciliation), which handles
+> identity deduplication after parsing.
+
 ## Summary
 
 The gram notation is a flexible representation of composable data structures that are

--- a/proposals/pattern-reconciliation.md
+++ b/proposals/pattern-reconciliation.md
@@ -1,5 +1,7 @@
 # Proposal: Pattern Reconciliation for pattern-hs
 
+> **Superseded by [RFC-010: Pattern Reconciliation](design/RFC-010-pattern-reconciliation.md)**
+
 ## Summary
 
 Add a `reconcile` operation to `Pattern.Core` that normalizes patterns by resolving duplicate identities and completing partial references. This transforms a potentially inconsistent `Pattern Subject` (from parsing, streaming, or merging) into a coherent one where each identity appears exactly once with fully resolved content.

--- a/proposals/pipeline-scenarios.md
+++ b/proposals/pipeline-scenarios.md
@@ -1,5 +1,10 @@
 # Motivating Scenarios: Graph Pipelines
 
+> **Superseded by [RFC-008: GraphTransform](design/RFC-008-graph-transform.md)**
+> 
+> The three motivating scenarios and the unified pipeline model from this document
+> are incorporated into RFC-008.
+
 **Purpose**: Grounding examples for the graph transformation feature proposal and
 related design decisions. These scenarios were developed to identify common requirements
 across realistic graph construction and transformation workloads.

--- a/proposals/representation-map-proposal.md
+++ b/proposals/representation-map-proposal.md
@@ -1,5 +1,12 @@
 # Proposal: RepresentationMap for pattern-hs
 
+> **Superseded by [RFC-006: Scope Unification](design/RFC-006-scope-unification.md) and
+> [RFC-007: RepresentationMap](design/RFC-007-representation-map.md)**
+> 
+> This document is split: the scope unification section (ScopeQuery, ScopeDict,
+> paraWithScope, interface convention) became RFC-006; the RepresentationMap section
+> (PatternKind, RepresentationMap, conventions, composability) became RFC-007.
+
 **Status:** Design — forward-looking, not yet a specification  
 **Date:** 2026-03-17  
 **Depends on:** GraphTransform proposal, pattern-equivalence proposal  

--- a/proposals/scope-unification-proposal.md
+++ b/proposals/scope-unification-proposal.md
@@ -1,5 +1,7 @@
 # Proposal: Scope Unification — `ScopeQuery` and `paraWithScope`
 
+> **Superseded by [RFC-006: Scope Unification](design/RFC-006-scope-unification.md)**
+
 **Status:** Design — ready for Haskell prototype  
 **Date:** 2026-03-17  
 **Depends on:** GraphQuery proposal (design only; `GraphQuery` record must be in scope)  


### PR DESCRIPTION
Creates nine new RFCs in proposals/design/ following the format established
by RFC-001 (Strata and Aspects), and adds an RFC index (README.md).

Key changes addressing redundancy, inconsistency, and outdated content:

- RFC-002: Consolidates DESIGN.md + pattern-category.md into a single
  authoritative reference for the Pattern container and graph substrate.
  Removes stale "⏳ Planned" markers that contradicted the "✅ Implemented"
  status header. Fixes the truncated Q&A fragment that appeared at the
  top of pattern-category.md as an authoring artifact.

- RFC-003: Merges SEMANTICS.md + EXTENDED-SEMANTICS.md (which shared ~70%
  of their content) into a single unified gram notation semantics reference.

- RFC-006: Extracts the ScopeQuery/paraWithScope design from
  representation-map-proposal.md (which duplicated scope-unification-proposal.md)
  into a self-contained RFC. Establishes the going-forward interface convention
  (typeclass + *Dict record).

- RFC-007: Covers RepresentationMap cleanly, referencing RFC-006 for scope
  machinery rather than re-specifying it.

- RFC-004, RFC-005, RFC-008, RFC-009, RFC-010: Convert graph-classifier.md,
  graph-query.md, graph-transform.md + pipeline-scenarios.md, graph-mutation.md,
  and pattern-reconciliation.md to RFC format with standard headers.

Superseded documents retain their content with prominent redirect notices.
pattern-equivalence.md is marked as a pre-RFC stub (motivating examples only,
needs full design before implementation).

https://claude.ai/code/session_015PWh3pTKm9QWuxtNFX5Tkt