### PR TITLE
RFC-011: Codec — pluggable persistence adapters for Pattern

### DIFF
--- a/.claude/skills/rfc-creator/SKILL.md
+++ b/.claude/skills/rfc-creator/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: rfc-creator
+description: Create or update Requests for Comment for this repository. Use when the user wants a new feature, subsystem, module, game mechanic, API change, or vendor contribution proposal drafted in `proposals/rfc/` before implementation.
+---
+
+# RFC Creator
+
+## Overview
+Use this skill to draft repository-specific RFCs that follow `proposals/rfc/README.md` exactly. RFCs are for proposals before implementation, not for settled architectural decisions.
+
+## Workflow
+1. Read `proposals/rfc/README.md` and any relevant context from `README.md`, `docs/project-overview.md`, and `docs/architecture.md`.
+2. Confirm the change belongs in an RFC:
+   - new subsystem, module, or feature
+   - significant behavior or API change
+   - vendor contribution introducing new interfaces or behavior
+3. Determine the next RFC number from the index in `proposals/rfc/README.md` (highest existing `RFC-NNN` + 1). Filename is `RFC-NNN-short-title.md` — `NNN` zero-padded to three digits, `short-title` in lowercase kebab-case (e.g. `RFC-011-codec-persistence.md`).
+4. Create a branch named `proposal/RFC-NNN-short-title` matching the RFC filename exactly before writing any files. Do not proceed without switching to this branch.
+5. Create or update `proposals/rfc/RFC-NNN-short-title.md` on that branch.
+6. Use this structure exactly. The five `##` sections are required and in this order; the header fields below `**Date:**` are optional — include the ones that apply, omit the rest:
+
+```markdown
+# RFC-NNN: Title
+
+**Status:** draft | under review | accepted | rejected
+**Date:** YYYY-MM-DD
+**Authors:** @handle
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Supersedes:** prior proposal/doc this RFC absorbs (note it as removed)
+**Depends on:** RFC-NNN (one-line reason), ...
+**Followed by:** what comes after this RFC lands (e.g. Rust port, CLI surface)
+**Related modules:** `Module.One`, `Module.Two`
+
+## Summary
+
+## Motivation
+
+## Design
+
+## Open Questions
+
+## Alternatives
+```
+
+## Writing Rules
+- Keep `## Summary` to one clear paragraph that states the device/change and how it relates to existing RFCs.
+- Lead `## Motivation` with the problem; use named sub-sections (e.g. "Why not X?", "Use Cases") when it sharpens the case.
+- Put interfaces, flows, and pseudocode in `## Design` when useful. Common `## Design` sub-sections in this repo: a named **Conventions** subsection when invertibility/round-tripping relies on encoded metadata, an **Implementation Sequence** (numbered, phased), and a **port** step (`pattern-rs` / TypeScript) when the design is meant to be ported.
+- Use `## Open Questions` to surface unresolved choices instead of hiding them; number them.
+- Compare realistic alternatives, not strawmen, and state why each is rejected.
+- Keep the proposal consistent with the current architecture unless the RFC explicitly challenges it.
+
+## Output
+When creating a new RFC:
+1. Confirm the active branch is `proposal/RFC-NNN-short-title` before writing files.
+2. Write the RFC file under `proposals/rfc/`.
+3. Update `proposals/rfc/README.md`: add the RFC to the appropriate category section's index table (or create a new section if it opens a new area), and reflect any new dependency in the Implementation Order diagram.
+4. Call out missing inputs or unresolved dependencies.
+5. Remind the author to run `/rfc-review` before opening the proposal for comment.

--- a/.claude/skills/rfc-creator/agents/openai.yaml
+++ b/.claude/skills/rfc-creator/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "RFC Creator"
+  short_description: "Draft repository RFCs from the local template"

--- a/.claude/skills/rfc-review/SKILL.md
+++ b/.claude/skills/rfc-review/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: rfc-review
+description: Review a draft RFC for scope, clarity, and contributor-readiness. Use before opening an RFC for comment or merging a proposal branch. Produces concrete suggested revisions, not just a report.
+---
+
+# RFC Review
+
+## Overview
+Use this skill to evaluate a draft RFC against a consistent set of quality criteria before it is opened for comment. Works for self-review by the author, maintainer review during a PR, or peer feedback from a collaborator. Produces specific, actionable suggested revisions — not a checklist of observations.
+
+## Workflow
+1. Read the RFC in `proposals/rfc/`.
+2. Read `proposals/rfc/README.md` to confirm structural compliance.
+3. Evaluate the RFC against each criterion below.
+4. For each criterion that fails or is weak, draft a specific suggested revision — quote the problematic text and propose replacement text or a concrete addition.
+5. Summarize findings: what is strong, what needs revision, and what is blocking vs. advisory.
+
+## Review Criteria
+
+### 1. Scope fit
+Is the RFC the right size for its stated purpose?
+- A PoC RFC should specify layout and boundaries, not implementation detail.
+- A feature RFC should specify behavior and interfaces, not code.
+- A subsystem RFC should specify contracts and failure modes, not algorithms.
+
+**Flag:** RFC specifies code, method signatures, or implementation detail that belongs in the implementation, not the proposal.  
+**Flag:** RFC is so vague that an implementer would face constant ambiguity about what was agreed.
+
+### 2. Acceptance criteria anchored in behavior
+Can a contributor tell when the work is done by observing something, not by checking off packages created?
+- Acceptance criteria should describe what a user, agent, or system *does* and *sees*.
+- Package structure and file layout are not acceptance criteria.
+
+**Flag:** No user stories, demo scenario, or observable acceptance criteria present.  
+**Flag:** Acceptance criteria describe structure ("the registry package exists") rather than behavior ("a ghost can register and receive a token").
+
+### 3. Demo scenario
+Is there a concrete path a contributor follows to verify the work?
+- Should include: what to run, in what order, and what to observe.
+- Should be completable by a new contributor within a stated time (e.g. 15 minutes).
+
+**Flag:** No demo scenario or "getting started" path described.  
+**Flag:** Demo scenario assumes knowledge not present in the RFC or repo README.
+
+### 4. Implementation readiness
+Is there enough information for implementation to begin without another round of design?
+- Key interfaces, tool names, or API shapes should be named (not fully specified).
+- Open questions should be listed explicitly, not hidden.
+- Dependencies between packages should be clear.
+
+**Flag:** A contributor would need to make significant design decisions not acknowledged as open questions.  
+**Flag:** Open questions are present but not listed — they are buried in prose or implicit.
+
+### 5. Over-specification
+Is the RFC constraining implementation detail that should be left to the implementer?
+- Method signatures, data structure internals, and algorithm choices belong in code.
+- Interface names and tool names are appropriate to specify; their implementations are not.
+
+**Flag:** Code blocks present that specify implementation rather than illustrate intent.  
+**Flag:** RFC would be wrong if an implementer chose a different variable name or data structure.
+
+### 6. Alternatives
+Are the alternatives realistic comparisons that help a reader understand why this approach was chosen?
+- Each alternative should name a real option that was genuinely considered.
+- Rejection reasons should be specific to this project, not generic.
+
+**Flag:** Alternatives are strawmen that no contributor would actually propose.  
+**Flag:** A significant alternative is missing — one a reviewer would ask "why not X?" about.
+
+### 7. Consistency with architecture
+Does the RFC align with decided components and open questions in `docs/architecture.md`?
+- It should not silently contradict decided technology choices.
+- If it resolves an open question, it should say so explicitly.
+- If it challenges a decided component, it should reference or propose an ADR.
+
+**Flag:** RFC introduces a technology or pattern inconsistent with `docs/architecture.md` without explanation.
+
+## Output Format
+
+```
+## RFC Review: [RFC title]
+
+### Summary
+[2-3 sentences: overall assessment and whether it is ready to open for comment]
+
+### Blocking Issues
+[Issues that must be resolved before the RFC is ready. For each: criterion, problem, suggested revision.]
+
+### Advisory Issues
+[Issues worth addressing but not blocking. Same format.]
+
+### Strengths
+[What is working well and should be preserved.]
+```
+
+For each blocking or advisory issue, include:
+- **Criterion:** which of the seven criteria applies
+- **Problem:** what is wrong or missing, with a quote if relevant
+- **Suggestion:** specific text to add, remove, or replace

--- a/proposals/rfc/README.md
+++ b/proposals/rfc/README.md
@@ -38,6 +38,12 @@ Design, Open Questions, Alternatives.
 | [RFC-008](RFC-008-graph-transform.md) | GraphTransform — Construction, Transformation, Pipeline | draft | RFC-004, RFC-005 |
 | [RFC-009](RFC-009-graph-mutation.md) | GraphMutation — Coherent In-Memory Graph Mutations | draft | RFC-004, RFC-005, RFC-008 |
 
+### Persistence Layer (Draft — Design)
+
+| RFC | Title | Status | Depends on |
+|-----|-------|--------|------------|
+| [RFC-011](RFC-011-codec-persistence.md) | Codec — Pluggable Persistence Adapters | draft | RFC-001, RFC-007, RFC-004 |
+
 ## Implementation Order
 
 The graph interface RFCs form a dependency chain:
@@ -45,10 +51,13 @@ The graph interface RFCs form a dependency chain:
 ```
 RFC-004 (GraphClassifier)
   └── RFC-005 (GraphQuery)
-        ├── RFC-006 (ScopeQuery)  ──→  RFC-007 (RepresentationMap)
+        ├── RFC-006 (ScopeQuery)  ──→  RFC-007 (RepresentationMap)  ──→  RFC-011 (Codec)
         └── RFC-008 (GraphTransform)
               └── RFC-009 (GraphMutation)
 ```
+
+RFC-011 (Codec) builds on RFC-007: a `RepresentationMap` normalizes shape within
+Pattern-space, then a `Codec` crosses the boundary into an external store.
 
 RFC-007 (RepresentationMap) additionally depends on RFC-008 (GraphTransform) being
 settled first, since it builds on `paraWithScope` and the GraphTransform primitives.

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -191,27 +191,44 @@ convention and becomes the direct image of RFC-001's principle 2.
 
 Logical schema — column names and relationships are the contract; physical types are
 transport-specific (`array<…>` is `text[]` in Postgres, `LIST` in DuckDB/Arrow; `json` is
-`jsonb` or a columnar struct):
+`jsonb` or a columnar struct). Subject identity is **frame-scoped** (the same identity may
+recur across Frames), so `frame_row`'s key is composite `(frame_id, id)` — which is what
+forces endpoint FKs to carry a frame id:
 
 ```
 -- frame-table : within-module structure, self-contained, faithful
 frame(frame_id, root_id)
 frame_row(frame_id, id, labels array<text>, properties json, elements array<id>)
-                                          -- ordered FK array = elements; refs stay in-frame
+  PRIMARY KEY (frame_id, id)              -- identity is frame-scoped
+                                          -- elements: ordered, refs stay in-frame; an array, so
+                                          -- NOT FK-enforceable — dangling element refs are DanglingRef
 
 -- span-table : the Span's Subject + its (0..1) Bundle's Subject, denormalized
 span(span_id, subject_id, labels array<text>, properties json, frame_a, frame_b,
      bundle_id?, bundle_labels array<text>?, bundle_properties json?)
-                                          -- Span Subject: subject_id/labels/properties
+  PRIMARY KEY (span_id)
+  UNIQUE (span_id, frame_a), UNIQUE (span_id, frame_b)   -- enable the through-span FKs below
                                           -- Bundle Subject (if any): bundle_* ; bundle_id is an
                                           -- attribute, NOT an FK (there is no bundle table)
 
 -- bundle_pair : the Bundle's pair-elements — one row per inter-frame relationship (the edge table)
-bundle_pair(span_id, src_ref, tgt_ref, pair_subject_id?, labels array<text>, properties json)
+bundle_pair(span_id, src_frame, src_ref, tgt_frame, tgt_ref, pair_subject_id?,
+            labels array<text>, properties json)
+  FOREIGN KEY (span_id)            REFERENCES span(span_id)              -- cascade-on-delete
+  FOREIGN KEY (span_id, src_frame) REFERENCES span(span_id, frame_a)    -- src_frame = the span's frame_a
+  FOREIGN KEY (span_id, tgt_frame) REFERENCES span(span_id, frame_b)    -- tgt_frame = the span's frame_b
+  FOREIGN KEY (src_frame, src_ref) REFERENCES frame_row(frame_id, id)   -- src endpoint exists in that frame
+  FOREIGN KEY (tgt_frame, tgt_ref) REFERENCES frame_row(frame_id, id)   -- tgt endpoint exists in that frame
                                           -- keyed by span_id (span:bundle is 1:0..1, so span_id
-                                          -- functionally determines the bundle), cascade-on-delete;
-                                          -- src_ref ∈ frame_a, tgt_ref ∈ frame_b : real FKs
+                                          -- functionally determines the bundle)
 ```
+
+The endpoint frame ids (`src_frame`/`tgt_frame`) are duplicated from the span deliberately:
+under frame-scoped identity they are required for *any* endpoint FK, and the through-span
+FKs additionally make the externality invariant declarative — a pair-element may only connect
+`frame_a` content to `frame_b` content, enforced by the database rather than by application
+code. (A global surrogate key on `frame_row` would avoid the duplication but reduce the
+endpoint FKs to "exists somewhere," losing frame-pair correctness; see Alternatives.)
 
 **Decisions baked in (settled in design review):**
 
@@ -352,11 +369,12 @@ saveVia (patternToGraph appDomain) graphCodec scope p  -- arbitrary pattern into
 `decode` is **total** — it returns `Either DecodeError`, never throws — and classifies
 failures via `DecodeError`: `KindViolation` (stored data does not satisfy `targetKind`,
 e.g. schema drift), `MissingConvention` (an ambiguous shape under a lossy map lacks its
-discriminator), `MalformedValue` (an unparseable cell), and `DanglingRef` (an `elements` or
-`bundle_pair` endpoint FK references an absent row — the integrity hazard that array-of-FK and
-the edge table cannot have the database enforce in every transport). `persist` is atomic at
-the single-unit granularity; multi-statement transactional and bulk writes are deferred
-(Open Question 2).
+discriminator), `MalformedValue` (an unparseable cell), and `DanglingRef` (a reference to an
+absent row). `bundle_pair` endpoints are FK-enforced where the transport supports composite
+FKs, so `DanglingRef` there is a backstop for transports that do not; the `frame_row.elements`
+array is *not* FK-enforceable in standard SQL, so dangling element refs are decode-time
+`DanglingRef` checks regardless of transport. `persist` is atomic at the single-unit
+granularity; multi-statement transactional and bulk writes are deferred (Open Question 2).
 
 ### The seed-then-own use case
 
@@ -450,6 +468,15 @@ it duplicates shape logic across backends (relational-into-a-graph-store would b
 codec instead of `relationalToGraph >>> graphCodec`), cannot reuse the subsumption embeddings,
 and hides *where* loss is introduced. Thin codecs + `RepresentationMap` chains keep loss
 declared and tested in one place (RFC-007).
+
+**Global surrogate key on `frame_row` (instead of frame-scoped `(frame_id, id)`).** Would let
+`bundle_pair` endpoints be single-column FKs with no `src_frame`/`tgt_frame` duplication.
+Rejected as the default: Subject identity is frame-scoped (the same identity may recur across
+Frames), so a global key requires minting surrogate ids and an identity-resolution layer, and
+— more importantly — it reduces endpoint FKs to "exists somewhere," forfeiting FK-level
+enforcement of the externality invariant (an endpoint must live in the span's `frame_a`/`frame_b`).
+Carrying the two frame columns is cheap and makes that invariant declarative. A global key
+remains available to a transport that prefers it, at that cost.
 
 **Shared Bundles persisted by reference (`bundle_id` grouping).** Tempting for storage dedup
 and faithful to RFC-001's in-memory sharing. Rejected as the *default* at scale: a shared

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -469,11 +469,12 @@ Open Question 3).
 
 ### Relationship to Gram.Schema
 
-Long-term, the `PatternKind`s and the embedding `conventions` should be *generated* from the
+Long-term, the `PatternKind`s and the embedding `conventions` could be *generated* from the
 same schema that already drives `Gram.Schema`'s TypeScript/Rust type generation — one
 `label → type` declaration projecting into the typed view, the Frame/Span table layout, and
-the graph discriminator set. This RFC specifies the devices; schema-driven generation is a
-follow-on.
+the graph discriminator set. This RFC specifies the devices and hand-writes them; generation
+is **deliberately deferred** — the stack is too immature to automate before we have hand-written
+several codecs and kinds and learned what actually recurs (Open Question 6).
 
 ### Acceptance criteria
 
@@ -555,8 +556,11 @@ is the first port — the immediate need in `aie-matrix`.
    composition ergonomics are understood, a registry would be premature abstraction over a
    single example. Representations are assembled explicitly at call sites via `saveVia` /
    `loadVia`; the registry is revisited once there is enough variety to generalize from.
-6. **Schema-driven generation.** How much of the kinds, table layout, and graph conventions
-   can `Gram.Schema` generate vs. hand-write? Park until the hand-written versions are stable.
+6. **Schema-driven generation. — Resolved: deferred (deliberate).** Generating the kinds,
+   table layout, and graph conventions from `Gram.Schema` is premature: the whole stack is too
+   immature to automate. The codecs and kinds are hand-written first; only after exercising
+   several of them — and seeing what genuinely recurs — is there expertise to generate from.
+   Revisit once the hand-written versions are stable.
 7. **Streaming / partial load.** Large stores will not fit one `Pattern` in memory. A
    streaming codec variant, or a `Store`-level cursor + fold?
 

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -1,0 +1,469 @@
+# RFC-011: Codec — Pluggable Persistence Adapters for Pattern
+
+**Status:** draft
+**Date:** 2026-06-18
+**Authors:** @akollegger
+**Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
+**Depends on:** RFC-001 (Frames and Spans), RFC-007 (RepresentationMap, PatternKind), RFC-004 (GraphClassifier kinds)
+**Followed by:** Rust/TypeScript ports (`pattern-rs`) → downstream adoption (`aie-matrix`)
+**Related modules:** `Pattern.Core`, `Pattern.RepresentationMap`, `Pattern.Frame`, `Pattern.Span`, `Pattern.Codec` (new), `Gram.JSON`, `Gram.Schema`
+
+## Summary
+
+Introduce `Codec` as the thin device that crosses the boundary between a *normalized*
+`Pattern v` and an external store's bytes. Persistence factors into **three independent
+axes**: the **target data model** is a `PatternKind` (RFC-007); the **encoding strategy**
+that adapts a pattern into that model is a chain of `RepresentationMap`s; and the
+**transport** that reads and writes bytes is a separate `Store`. A `Codec` binds one
+`PatternKind` to one transport and is *faithful for that kind by construction* — fidelity
+is a property of the `RepresentationMap` chain, not a codec flag. Two regimes follow from
+where a target model sits in the model **subsumption lattice**: a **faithful** regime — the
+**Frame/Span two-table encoding**, which is the relational/columnar realization of
+RFC-001's by-reference storage form, where the externality discipline (a Frame does not
+hold its cross-Frame edges; the Span does) *is* the node-table/edge-table split — and a
+**lossy** regime — projection onto a native graph store's smaller vocabulary, which needs
+discriminator conventions or is treated as a one-way projection. Because the model
+relationships are themselves `RepresentationMap`s, "alternative representations with
+different qualities" become different map chains composed before the same thin codec.
+
+## Motivation
+
+For any data structure to be adopted, it needs a credible story for persisting at scale in
+a real database. Pattern has in-memory operations and a canonical JSON encoding
+(`Gram.JSON`), but no first-class, fidelity-aware way to land a `Pattern v` in a store, in
+a chosen *representation*, and reconstruct it.
+
+### Three axes, not "a codec per backend"
+
+A naïve design writes "the relational codec" and "the graph codec" as parallel siblings.
+That conflates three things that vary independently:
+
+1. **Target data model** — the abstract model a representation targets (Frame/Span tables,
+   property-graph, document). *This is a `PatternKind`* — a recognizable shape of
+   `Pattern v` (RFC-004/007).
+2. **Encoding strategy** — *how* a source pattern is adapted into that model, with
+   differing qualities. This is a `RepresentationMap` chain (RFC-007).
+3. **Transport** — where the bytes live and how you talk to it (Neo4j driver, Postgres,
+   DuckDB/columnar, Mongo, KV). This is a `Store`.
+
+A *representation* is a point in the product of these axes. The same transport can host
+several representations (Postgres can hold a faithful JSONB document *and* the Frame/Span
+tables); the same target model can be served by several strategies. Collapsing the axes
+hides that structure and forces duplication.
+
+### The models subsume each other — and split into two fidelity regimes
+
+The target models form a **subsumption lattice**, with `Pattern` itself at the top.
+Faithful *encodings* sit at the top tier (they hold everything a `Pattern Subject` carries);
+genuinely less-expressive *models* sit below:
+
+```
+Pattern                       ordered nesting + n-ary elements + decoration — most expressive
+  │
+  ├─ faithful encodings (≈ Pattern):
+  │     document / tree        nested JSON; whole-pattern I/O
+  │     Frame/Span tables      node table + edge table; by-reference storage form
+  │
+  └─ subsumed models (below Pattern):
+        property-graph         nodes, typed relationships, properties
+          └── relational       tables = labels, join tables = relationships, scalar attrs
+```
+
+Where a model sits determines its **fidelity regime**:
+
+- **Faithful regime** — models at/near the top (`document`, `Frame/Span tables`) hold
+  everything a `Pattern Subject` carries. Reached by a *lossless* `RepresentationMap`; no
+  information is dropped.
+- **Lossy regime** — the *native* property-graph vocabulary (Neo4j nodes/typed-rels with
+  scalar-only properties) sits strictly below `Pattern` (no ordered nesting, no n-ary).
+  Projecting an arbitrary pattern onto it loses information unless conventions re-encode
+  the residual in-band, or it is accepted as a one-way query projection.
+
+### Why a separate device at all?
+
+`RepresentationMap` is `Pattern v → Pattern v` — pure shape adaptation within
+Pattern-space, including the model relationships above. A store is *not* a point in
+Pattern-space, so making it a `codomain` of a `RepresentationMap` is a category error: the
+boundary is effectful and deals in backend-native bytes. `Codec` is that boundary, and
+nothing more. The two compose:
+
+```
+Pattern --[RepresentationMap chain: choose/compose a target shape]--> Pattern(targetKind)
+        --[Codec: targetKind ⇄ bytes]--> Store
+```
+
+## Design
+
+### Fidelity is a consequence of subsumption — and splits cleanly into two regimes
+
+A codec serializes a *known kind* to bytes and back, so it is **faithful for its
+`targetKind` by construction**. Fidelity is therefore a property of the
+`RepresentationMap` chain that reaches the codec's `targetKind`, not a codec flag:
+
+> A representation is **faithful** iff its target model subsumes its source kind in the
+> lattice, *or* the chain's conventions re-encode the residual sufficient for a strict
+> round-trip (RFC-007's `roundTrip` witness holds on `domain`). Where neither holds — the
+> native graph store as a query-optimized projection with the canonical form held
+> elsewhere — the mapping is a one-way **projection**, not a `RepresentationMap`, and
+> round-trip is not claimed.
+
+This retires the earlier "lossy RepresentationMap" wording: a `RepresentationMap` is always
+invertible on its domain; loss lives either in declared conventions that *restore*
+invertibility, or in an explicitly one-way projection that is not a `RepresentationMap`.
+
+### `Codec` — bind a kind to a transport
+
+```haskell
+-- | The pure shape↔bytes mapping for ONE target kind against ONE backend model `b`.
+data Codec b v = Codec
+  { codecName  :: Text
+  , targetKind :: PatternKind v   -- the normalized kind this codec faithfully serializes
+  , encode     :: Pattern v -> b
+  , decode     :: b -> Either DecodeError (Pattern v)
+  }
+
+data DecodeError
+  = KindViolation   Text   -- stored data does not satisfy `targetKind`
+  | MissingConvention Text -- an ambiguous shape lacks the discriminator needed to invert
+  | MalformedValue  Text   -- a value column/cell could not be parsed
+  | DanglingRef     Text   -- an element/endpoint FK references a row that is absent
+  deriving (Eq, Show)
+```
+
+The codec performs no I/O; it only translates the shape it owns. This keeps it pure,
+property-testable without a database, and faithful for `targetKind`.
+
+### Transport is a separate concern
+
+```haskell
+class Monad m => Store b m where
+  persist  :: b -> m StoreKey
+  retrieve :: StoreQuery b -> m b
+```
+
+End-to-end save/load are thin compositions of a `RepresentationMap` chain (shape), a
+`Codec` (bytes), and a `Store` (transport). Use `idMap` when the source is already of the
+codec's `targetKind`:
+
+```haskell
+saveVia :: (Store b m, ScopeQuery q v)
+        => RepresentationMap v -> Codec b v -> q v -> Pattern v -> m StoreKey
+saveVia rmap codec scope = persist . encode codec . forward rmap scope
+
+loadVia :: (Store b m, ScopeQuery q v)
+        => Codec b v -> RepresentationMap v -> q v -> StoreQuery b
+        -> m (Either DecodeError (Pattern v))
+loadVia codec rmap scope q = do
+  b <- retrieve q
+  pure $ inverse rmap scope <$> decode codec b
+```
+
+### The faithful regime: the Frame/Span two-table encoding
+
+RFC-001 (§ What this RFC does not include) defers database-backed Frames to "a layer above
+pattern-hs," on the principle that the substrate is in-memory. **RFC-011 is that layer:**
+`Store` and `Codec` live in the persistence layer, the substrate gains nothing, and the
+in-memory by-value form remains canonical — storage is its by-reference projection.
+
+This is the relational/columnar realization of RFC-001's **by-reference storage form**,
+which RFC-001 (§ Inter-Frame topology) names as "the natural serialization-and-storage
+form." Its faithfulness is not an accident of schema design — it is the **externality
+discipline** of Frames and Spans serialized directly:
+
+- A **Frame** (RFC-001) is a self-contained module: its elements do not reach across to
+  other Frames. → a **frame-table** (the *node table*) of rows whose element FKs reference
+  only same-frame rows.
+- A **Span** (RFC-001) holds the cross-Frame correspondences (a Bundle of pair-elements)
+  *externally* — a Frame never holds its cross-Frame edges. → a **span-table** (the *edge
+  table*).
+
+"Every table is a label, every join table is a relationship" thus stops being an imposed
+convention and becomes the direct image of RFC-001's principle 2.
+
+| RFC-001 (in-memory, by-value) | RFC-011 (by-reference storage) |
+|---|---|
+| Frame (self-contained module) | a `frame_row` row-set under one `frame_id` |
+| Frame element (Pattern / Portal) | a row: Subject columns + ordered child-FK array |
+| Self-containment (Reading 1) | element FKs reference **only same-frame rows** |
+| Span (relates two Frames) + its Bundle | one `span` row (Span/Bundle Subjects on the row) |
+| Bundle pair-element (cross-Frame edge) | one `span_pair` row: `(span_id, src_ref, tgt_ref, …)` |
+| Externality (edges live in the Span) | edges live in `span_pair`, never in `frame_row` |
+
+Logical schema — column names and relationships are the contract; physical types are
+transport-specific (`array<…>` is `text[]` in Postgres, `LIST` in DuckDB/Arrow; `json` is
+`jsonb` or a columnar struct):
+
+```
+-- frame-table : within-module structure, self-contained, faithful
+frame(frame_id, root_id)
+frame_row(frame_id, id, labels array<text>, properties json, elements array<id>)
+                                          -- ordered FK array = elements; refs stay in-frame
+
+-- span-table : cross-module correspondences, externalized (the edge table)
+span(span_id, subject_id, labels array<text>, properties json,
+     frame_a, frame_b, bundle_id?)        -- Span/Bundle Subjects live on this row
+span_pair(span_id, src_ref, tgt_ref, pair_subject_id?, labels array<text>, properties json)
+                                          -- keyed by span_id, cascade-on-delete;
+                                          -- src_ref ∈ frame_a, tgt_ref ∈ frame_b : real FKs
+```
+
+**Decisions baked in (settled in design review):**
+
+- **Span and Bundle identities live on the `span` row**, not as separate entities — flatter
+  to query.
+- **Pair-elements are keyed by `span_id` and materialized per span**, not shared by
+  `bundle_id`. This makes each span self-contained — Frame self-containment applied to the
+  edge table — so `ON DELETE CASCADE` works, endpoint FKs are declarable (a bound span has
+  a single valid frame pair), and concurrent writers do not contend on shared edge rows.
+- **`bundle_id` is retained as a non-enforced grouping attribute** (a column, not an FK),
+  so the in-memory *shared* Bundle form (RFC-001 allows Bundle sharing) can be reconstituted
+  on read when two spans carry identical pairs under the same id — without the database ever
+  depending on it.
+- **Escape hatch** for a genuinely large, shared correspondence: promote the Bundle to a
+  first-class stored entity (it is a `Pattern Subject`, so it gets its own `frame_row`s)
+  with an explicit, managed lifecycle. Opt-in, eyes-open sharing — not the implicit default
+  that breaks cascade and FK enforcement.
+
+**Faithfulness.** The by-value ↔ by-reference relationship is a lossless
+`RepresentationMap` (resolve `FrameRef`/`SpanRef` through an `id → Pattern` map; RFC-001
+§ Inter-Frame topology):
+
+```haskell
+byReference :: RepresentationMap Subject      -- by-value Pattern  ↔  Frame/Span by-reference
+byReference = RepresentationMap
+  { name        = "by-value ↔ by-reference (Frame/Span)"
+  , domain      = anyPattern
+  , codomain    = frameSpanRefKind
+  , conventions = [ "Frames stored once; Spans reference Frames by identity"
+                  , "cross-Frame edges externalized as span_pair rows (RFC-001 principle 2)" ]
+  , forward     = toByReference
+  , inverse     = resolveByReference
+  , roundTrip   = byReferenceRoundTrip       -- strict on anyPattern with identified subjects
+  }
+```
+
+A **single frame-table** faithfully stores a lone self-contained Frame; **frame-table +
+span-table** scales it to the graphs-of-graphs RFC-001 motivates (the airplane modeled as
+mechanical / electrical / maintenance Frames related by Spans). This subsumes the looser
+"pattern-table" and "normalized-adjacency" sketches considered earlier — they are the
+one-Frame and many-narrow-tables points of this same principled encoding.
+
+### The lossy regime, and the two distinct "relational" stories
+
+There are two unrelated things that both touch "relational," and conflating them was a flaw
+in an earlier draft:
+
+1. **Pattern faithfully *encoded into* relational/columnar storage** — the Frame/Span tables
+   above. Uses an RDBMS or columnar store (Postgres, DuckDB/Parquet) as a *transport* for a
+   faithful encoding. This is the faithful regime.
+2. **The native relational *model*** (`relationalKind`: tables = labels, join tables = rels,
+   scalar attrs) — a *subset of property-graph*, for **interoperating with existing
+   relational data**. The relational ↪ property-graph embedding is an ordinary
+   `RepresentationMap` whose `conventions` are the table/join-table rules:
+
+```haskell
+relationalToGraph :: RepresentationMap Subject   -- relational data ↪ property-graph
+relationalToGraph = RepresentationMap
+  { name        = "relational ↪ property-graph"
+  , domain      = relationalKind
+  , codomain    = graphKind
+  , conventions = [ "each table T -> nodes labeled T; columns -> node properties"
+                  , "foreign-key column -> relationship to the referenced node"
+                  , "M:N junction table -> relationship type; non-key columns -> rel properties" ]
+  , forward     = embedRelationalAsGraph
+  , inverse     = projectGraphAsRelational           -- partial: on the relational sub-kind
+  , roundTrip   = relationalRoundTrip
+  }
+```
+
+The genuinely **lossy** projection — an arbitrary pattern onto the *native* graph store
+vocabulary — is also a map, with discriminators emitted only on target shapes whose preimage
+is non-singleton (derivable from `domain`); restricting `domain` to an application's schema
+minimizes the tags:
+
+```haskell
+patternToGraph :: PatternKind Subject -> RepresentationMap Subject
+patternToGraph appDomain = RepresentationMap
+  { name        = "Pattern ↠ native property-graph"
+  , domain      = appDomain
+  , codomain    = graphKind
+  , conventions = [ "binary pattern -> relationship; tag _pk=binary only where it collides with a native relationship"
+                  , "annotation -> self-loop; tag _pk=annotation only where it collides with a self-reference"
+                  , "rich Value (VMap/VArray/VRange/VMeasurement/VTaggedString) -> decomposed sub-nodes or property_json" ]
+  , forward     = projectPatternAsGraph appDomain
+  , inverse     = liftGraphAsPattern appDomain
+  , roundTrip   = graphRoundTripOn appDomain          -- strict on appDomain; tags restore invertibility
+  }
+```
+
+Used as a faithful-with-tags map it satisfies `roundTrip`; used as a query projection with
+the canonical form held in Frame/Span storage, round-trip is simply not claimed.
+
+### Target kinds (grounding)
+
+- `frameKind` / `spanKind` — from RFC-001: a Frame is a self-contained `Pattern Subject`;
+  a Span is a relationship-shaped `Pattern Subject` (2–3 elements). `frameSpanRefKind` is the
+  by-reference composite (Frames once + Spans referencing them).
+- `graphKind` — RFC-004's graph classification (`GNode`/`GRelationship`/`GWalk`/`GAnnotation`).
+- `anyPattern` — the document model (≈ lattice top).
+- `relationalKind` — the native relational model. Its predicate is non-trivial because
+  relationality is largely about *references* (foreign keys), which are scope-relative rather
+  than locally structural; see Open Questions. If no clean predicate exists, `relationalKind`
+  is defined operationally as the `domain` of `relationalToGraph` — the three-axes story holds
+  either way, since the embedding, not a standalone predicate, is what interop needs.
+
+### Reference Codecs (thin, one `targetKind` each)
+
+```haskell
+documentCodec :: Codec Value Subject          -- document model ≈ Pattern (lattice top)
+documentCodec = Codec "document" anyPattern patternToValue decodeJSON
+  -- decodeJSON :: Value -> Either DecodeError (Pattern Subject), via patternFromValue
+
+frameSpanCodec :: Codec TwoTables Subject      -- the faithful Frame/Span tables (RDBMS / columnar)
+frameSpanCodec = Codec "frame-span" frameSpanRefKind toTwoTables fromTwoTables
+
+graphCodec :: Codec [GraphOp] Subject          -- native node/rel/property model
+graphCodec = Codec "neo4j" graphKind toGraphOps fromGraphResult
+```
+
+Representations are assembled by composition — *the* point of leaning on RFC-007:
+
+```haskell
+saveVia idMap            documentCodec  scope p   -- faithful document archival
+saveVia byReference      frameSpanCodec scope p   -- faithful Frame/Span tables (default for scale)
+saveVia relationalToGraph graphCodec    scope rel -- existing relational data into a graph store
+saveVia (patternToGraph appDomain) graphCodec scope p  -- arbitrary pattern into native Neo4j
+```
+
+### Failure modes
+
+`decode` is **total** — it returns `Either DecodeError`, never throws — and classifies
+failures via `DecodeError`: `KindViolation` (stored data does not satisfy `targetKind`,
+e.g. schema drift), `MissingConvention` (an ambiguous shape under a lossy map lacks its
+discriminator), `MalformedValue` (an unparseable cell), and `DanglingRef` (an `elements` or
+`span_pair` endpoint FK references an absent row — the integrity hazard that array-of-FK and
+the edge table cannot have the database enforce in every transport). `persist` is atomic at
+the single-unit granularity; multi-statement transactional and bulk writes are deferred
+(Open Question 2).
+
+### The seed-then-own use case
+
+Seed a store from gram-authored `Pattern`, then treat the store as the source of truth.
+Two postures:
+
+- **Faithful (Frame/Span tables):** `saveVia byReference frameSpanCodec` seeds; runtime reads
+  round-trip losslessly. Use when the store must be authoritative without loss.
+- **Native graph (Neo4j as SoT):** `saveVia (patternToGraph appDomain) graphCodec` seeds. At
+  runtime the decode domain is the application's schema, shrinking discriminators to the few
+  app shapes that collide; the canonical form may also be retained in Frame/Span storage,
+  making Neo4j a query projection.
+
+### Relationship to Gram.Schema
+
+Long-term, the `PatternKind`s and the embedding `conventions` should be *generated* from the
+same schema that already drives `Gram.Schema`'s TypeScript/Rust type generation — one
+`label → type` declaration projecting into the typed view, the Frame/Span table layout, and
+the graph discriminator set. This RFC specifies the devices; schema-driven generation is a
+follow-on.
+
+### Acceptance criteria
+
+Observable, regardless of file/package layout:
+
+1. `saveVia idMap documentCodec` round-trips any `Pattern Subject` byte-for-byte through
+   `Gram.JSON`.
+2. Seeding a multi-Frame pattern (e.g. an `aie-matrix` NPC + map + calendar config) via
+   `saveVia byReference frameSpanCodec`, then `loadVia`, yields a `Pattern` structurally
+   equal to the original — including cross-Frame correspondences, which appear as
+   `span_pair` rows and never inside any frame.
+3. Deleting a `span` row removes exactly its `span_pair` rows (cascade) and no `frame_row`s.
+4. `decode` of a row set with a dangling endpoint FK returns `Left (DanglingRef …)`, never
+   throws.
+
+### Implementation Sequence
+
+**Step 1 — Codec, Store, faithful document baseline.** Define `Codec`, `DecodeError`,
+`Store`, `saveVia`/`loadVia`; implement `documentCodec` over `Gram.JSON`; Hedgehog
+round-trip; in-memory `Store` fake. **Demo (~15 min, no database):** round-trip
+`examples/*.gram` through `documentCodec` against the in-memory `Store` and assert
+structural equality.
+
+**Step 2 — Frame/Span tables.** Define `frameKind`/`spanKind`/`frameSpanRefKind` over RFC-001;
+implement `byReference` as a `RepresentationMap` and prove its round-trip with RFC-007's
+harness; implement `frameSpanCodec`; verify acceptance criteria 2–4 against the in-memory and
+a SQLite `Store`.
+
+**Step 3 — Native graph + relational interop + real driver.** Implement `patternToGraph`
+(lossy, declared conventions) and `relationalToGraph` (faithful embedding); `graphCodec`;
+provide a real `Store [GraphOp] IO` against a Neo4j driver (outside the pure library).
+
+**Step 4 — Ports** (`pattern-rs`, TypeScript). The pure `Codec` and the `RepresentationMap`s
+port directly; `Store` is implemented per language against native drivers. The document codec
+is the first port — the immediate need in `aie-matrix`.
+
+## Open Questions
+
+1. **`relationalKind` expressibility.** Is the native relational model expressible as a
+   `PatternKind` predicate, given foreign keys are scope-relative rather than locally
+   structural? If a clean predicate is impractical, does relational interop need a weaker
+   classification than graph/document, or to be specified only by its embedding map?
+2. **Batching / transactionality.** `persist` is one-unit-at-a-time. Bulk seeding and
+   transactional multi-statement writes need a batch surface (`persistMany`,
+   `withTransaction`). `Store`, or a layer above?
+3. **Identity and upsert.** `StoreKey` vs. `Subject.identity`. When the store owns identity
+   (post-seed), how does decode reconcile store keys with pattern identities? Likely a
+   per-codec identity strategy, coordinated with RFC-010 reconciliation.
+4. **Shared-Bundle reconstruction.** On read, should identical `span_pair` sets under one
+   `bundle_id` be reconstituted as a shared in-memory Bundle automatically, or only on
+   explicit request? Default leans explicit, to keep the read path simple.
+5. **Representation registry.** A catalog of `(model × strategy) → (map chain, codec)` so
+   callers pick by desired qualities. **Deferred:** park until at least two embeddings exist;
+   until then, representations are assembled explicitly at call sites.
+6. **Schema-driven generation.** How much of the kinds, table layout, and graph conventions
+   can `Gram.Schema` generate vs. hand-write? Park until the hand-written versions are stable.
+7. **Streaming / partial load.** Large stores will not fit one `Pattern` in memory. A
+   streaming codec variant, or a `Store`-level cursor + fold?
+
+## Alternatives
+
+**Extend `RepresentationMap` to target stores directly** — make a database a `codomain`.
+Rejected as a category error: a store is not a `Pattern v`, the boundary is effectful, and
+serialization deals in backend bytes. This RFC *does* lean on `RepresentationMap` for the
+entire shape half — including the by-reference Frame/Span encoding and model subsumption —
+and adds only the thin boundary crossing.
+
+**Monolithic per-backend codecs that bake in shape strategy** — "the relational codec", "the
+graph codec" as siblings, each embedding its own shape decisions and fidelity flag. Rejected:
+it duplicates shape logic across backends (relational-into-a-graph-store would be a whole new
+codec instead of `relationalToGraph >>> graphCodec`), cannot reuse the subsumption embeddings,
+and hides *where* loss is introduced. Thin codecs + `RepresentationMap` chains keep loss
+declared and tested in one place (RFC-007).
+
+**Shared Bundles persisted by reference (`bundle_id` grouping).** Tempting for storage dedup
+and faithful to RFC-001's in-memory sharing. Rejected as the *default* at scale: a shared
+Bundle has no single owning Span, so `ON DELETE CASCADE` cannot apply (forcing app-level
+refcount/GC), endpoint foreign keys become undeclarable (no single valid frame pair), and
+concurrent writers contend on shared edge rows. Storage materializes per span; sharing is
+preserved as an in-memory/read-time reconstruction (`bundle_id` as a non-enforced attribute)
+and an explicit promote-to-entity escape hatch.
+
+**An existing Haskell persistence library as the whole answer** (`persistent`, `beam`,
+`esqueleto`, `hasql`). Rejected as a *replacement* for these devices: they map *records* to
+tables and do not model a recursive meta-structure or its shape strategy. They remain strong
+candidates to *implement* a `Store` (and a backend `Codec`'s encode/decode against SQL) — they
+are a transport-layer choice, not a substitute for the kind/representation machinery.
+
+**An OGM-style rich object layer** — map `Pattern` to stateful domain objects with
+lazy-loading and an identity map, then persist the objects. Rejected for the reasons the wider
+ORM history and the Haskell ecosystem reject it: it reintroduces the impedance mismatch, adds a
+third source of truth, and centers a mutable object graph that `Pattern` is specifically better
+than. OO ergonomics belong in a *view/lens* over `Pattern`, not in the persistence path.
+
+**One canonical store only** (e.g. "everything is a document"). Simplest, and `documentCodec`
+already covers it as the default. Rejected as the *whole* answer because adoption needs native
+query power (SQL, Cypher) and scalable storage for some workloads; the axes let each deployment
+choose its fidelity/queryability trade-off rather than imposing one.
+
+**Hand-rolled per-application persistence** — the status quo in `aie-matrix`
+(`Pattern → OO → Neo4j`, by hand). Rejected: bespoke, untested round-trips, no declared
+fidelity, no reuse across ports — exactly the friction this RFC removes.

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -290,9 +290,10 @@ endpoint FKs to "exists somewhere," losing frame-pair correctness; see Alternati
   a single valid frame pair), and concurrent writers do not contend on shared edge rows.
 - **`bundle_id` is a non-enforced attribute** (a column, not an FK — it points at no table),
   retained so the in-memory *shared* Bundle form (RFC-001 allows Bundle sharing) can be
-  reconstituted on read when two spans carry identical pairs under the same id — without the
-  database ever depending on it. A third (`bundle`) table would be needed only to reintroduce
-  the rejected shared-bundle semantics; see Alternatives.
+  reconstituted on read *on explicit request* when two spans carry identical pairs under the
+  same id — not automatically, and without the database ever depending on it (Open Question 4).
+  A third (`bundle`) table would be needed only to reintroduce the rejected shared-bundle
+  semantics; see Alternatives.
 - **Escape hatch** for a genuinely large, shared correspondence: promote the Bundle to a
   first-class stored entity (it is a `Pattern Subject`, so it gets its own `frame_row`s)
   with an explicit, managed lifecycle. Opt-in, eyes-open sharing — not the implicit default
@@ -543,9 +544,11 @@ is the first port — the immediate need in `aie-matrix`.
    (parsing, RFC-010, Frame boundaries, persistence) that RFC-011 depends on; it warrants its
    own RFC (or an RFC-010 extension) and should be settled before RFC-011 implementation.
    Downstream (`aie-matrix`) is already hitting it.
-4. **Shared-Bundle reconstruction.** On read, should identical `bundle_pair` sets under one
-   `bundle_id` be reconstituted as a shared in-memory Bundle automatically, or only on
-   explicit request? Default leans explicit, to keep the read path simple.
+4. **Shared-Bundle reconstruction. — Resolved: explicit.** On read, decode produces the
+   materialized (per-span) Bundle as stored; identical `bundle_pair` sets under one `bundle_id`
+   are *not* automatically coalesced into a shared in-memory Bundle. Reconstituting sharing is
+   a deliberate, opt-in operation the caller requests — keeping the read path simple,
+   predictable, and free of implicit cross-span coupling.
 5. **Representation registry.** A catalog of `(model × strategy) → (map chain, codec)` so
    callers pick by desired qualities. **Deferred:** park until at least two embeddings exist;
    until then, representations are assembled explicitly at call sites.
@@ -583,8 +586,8 @@ and faithful to RFC-001's in-memory sharing. Rejected as the *default* at scale:
 Bundle has no single owning Span, so `ON DELETE CASCADE` cannot apply (forcing app-level
 refcount/GC), endpoint foreign keys become undeclarable (no single valid frame pair), and
 concurrent writers contend on shared edge rows. Storage materializes per span; sharing is
-preserved as an in-memory/read-time reconstruction (`bundle_id` as a non-enforced attribute)
-and an explicit promote-to-entity escape hatch.
+preserved as an *opt-in* read-time reconstruction (`bundle_id` as a non-enforced attribute;
+Open Question 4) and an explicit promote-to-entity escape hatch.
 
 **An existing Haskell persistence library as the whole answer** (`persistent`, `beam`,
 `esqueleto`, `hasql`). Rejected as a *replacement* for these devices: they map *records* to

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -5,6 +5,7 @@
 **Authors:** @akollegger
 **Repository:** [github.com/relateby/pattern-hs](https://github.com/relateby/pattern-hs)
 **Depends on:** RFC-001 (Frames and Spans), RFC-007 (RepresentationMap, PatternKind), RFC-004 (GraphClassifier kinds)
+**Prerequisite:** scoped identity namespaces — a future RFC (or RFC-010 extension) gating implementation; see Open Question 3
 **Followed by:** Rust/TypeScript ports (`pattern-rs`) → downstream adoption (`aie-matrix`)
 **Related modules:** `Pattern.Core`, `Pattern.RepresentationMap`, `Pattern.Frame`, `Pattern.Span`, `Pattern.Codec` (new), `Gram.JSON`, `Gram.Schema`
 
@@ -441,6 +442,30 @@ Two postures:
   app shapes that collide; the canonical form may also be retained in Frame/Span storage,
   making Neo4j a query projection.
 
+"Source of truth" here means the store owns the *data*, never the *identity*. Identity is
+owned by `Subject.identity` (next section).
+
+### Identity is owned by `Subject.identity`
+
+`Subject.identity` is the authoritative identity; the store never mints an identity of record.
+A `StoreKey` is a *physical locator* (row address, handle) subordinate to `Subject.identity` —
+decode resolves store keys back to subject identities, not the reverse. **Upsert keys on
+`Subject.identity`**, and write-time conflicts (same identity, differing labels/properties) are
+resolved by **RFC-010 reconciliation** — persistence get/put *is* the I/O boundary at which
+RFC-010 says reconciliation runs.
+
+This commits the local rule but leaves a larger problem open and **upstream**: scoped
+identity namespaces. Ingesting multiple `.gram` files clashes identities, because each file
+carries its own id-space (anonymous `#1`/`#2`, or human-chosen ids that collide across files).
+Resolving how id-spaces are scoped, qualified, or rewritten on ingest is a cross-cutting
+identity concern — it touches parsing, RFC-010 reconciliation, Frame boundaries, and this
+layer's upsert/dedup — and is **bigger than this RFC and a prerequisite for it.** Downstream
+(`aie-matrix`) is already hitting it. The Frame/Span schema's frame-scoped key `(frame_id, id)`
+— Frame as namespace — is this RFC's local manifestation of that scoping; the prerequisite must
+formalize how those frame namespaces are assigned so cross-file ingestion is clash-free. It
+warrants its own RFC (or an RFC-010 extension), settled before RFC-011 implementation (see
+Open Question 3).
+
 ### Relationship to Gram.Schema
 
 Long-term, the `PatternKind`s and the embedding `conventions` should be *generated* from the
@@ -464,6 +489,10 @@ Observable, regardless of file/package layout:
    throws.
 
 ### Implementation Sequence
+
+Steps 1–2 (faithful encode/decode and round-trip) need no identity scoping and can proceed
+immediately. **Upsert and seed-then-own, however, are gated on the scoped-identity-namespace
+prerequisite** (Open Question 3) — do not build identity-keyed upsert until that is settled.
 
 **Step 1 — Codec, Store, faithful document baseline.** Define `Codec`, `DecodeError`,
 `Store`, `saveVia`/`loadVia`; implement `documentCodec` over `Gram.JSON`; Hedgehog
@@ -505,9 +534,15 @@ is the first port — the immediate need in `aie-matrix`.
    multi-statement atomic writes (`persistMany`, `withTransaction`) are orchestration *over* a
    `Store` — transport-specific and orthogonal to encoding — so they live above the boundary,
    keeping `Store` instances trivial and the scope tidy (see § Transport is a separate concern).
-3. **Identity and upsert.** `StoreKey` vs. `Subject.identity`. When the store owns identity
-   (post-seed), how does decode reconcile store keys with pattern identities? Likely a
-   per-codec identity strategy, coordinated with RFC-010 reconciliation.
+3. **Identity and upsert. — Decided in principle; blocked on a prerequisite.** Identity is
+   owned by `Subject.identity`, not the store; `StoreKey` is a subordinate physical locator;
+   upsert keys on identity; write-time conflicts are RFC-010 reconciliation at the I/O boundary
+   (see § Identity is owned by `Subject.identity`). What remains open is **bigger than this RFC
+   and a prerequisite for it:** scoped identity namespaces for clash-free ingestion of multiple
+   `.gram` files (each carrying its own id-space). That is a cross-cutting identity concern
+   (parsing, RFC-010, Frame boundaries, persistence) that RFC-011 depends on; it warrants its
+   own RFC (or an RFC-010 extension) and should be settled before RFC-011 implementation.
+   Downstream (`aie-matrix`) is already hitting it.
 4. **Shared-Bundle reconstruction.** On read, should identical `bundle_pair` sets under one
    `bundle_id` be reconstituted as a shared in-memory Bundle automatically, or only on
    explicit request? Default leans explicit, to keep the read path simple.

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -204,15 +204,37 @@ codec's `targetKind`:
 ```haskell
 saveVia :: (Store b m, ScopeQuery q v)
         => RepresentationMap v -> Codec b v -> q v -> Pattern v -> m StoreKey
-saveVia rmap codec scope = persist . encode codec . forward rmap scope
+saveVia rmap codec scope = persist . encode codec . repMapForward rmap scope
 
 loadVia :: (Store b m, ScopeQuery q v)
         => Codec b v -> RepresentationMap v -> q v -> StoreQuery b
         -> m (Either DecodeError (Pattern v))
 loadVia codec rmap scope q = do
   b <- retrieve q
-  pure $ inverse rmap scope <$> decode codec b
+  pure (decode codec b >>= reconstruct rmap scope)
+  -- reconstruct = the load-path (partial) inverse: total for faithful maps;
+  -- Left (MissingConvention ...) where a lossy map's inverse needs an absent
+  -- discriminator. Binding through Either keeps that failure in the error channel
+  -- (a plain `repMapInverse <$> ...` would lose it). See "Dependency on RFC-007" below.
 ```
+
+### Dependency on RFC-007's `RepresentationMap`
+
+The map examples below use the field names of the *implemented* `Pattern.RepresentationMap`
+(`repMapName`, `repMapDomain`, `repMapCodomain`, `repMapForward`, `repMapInverse`,
+`repMapRoundTrip`). RFC-011 relies on two additions that RFC-007's draft anticipates but the
+current implementation does not yet carry — RFC-007 alignment work this RFC depends on:
+
+1. **`repMapConventions :: [Text]`** — the declared encoding decisions (the discriminator
+   rules) are central here; they are a lossy map's identity. The implemented type has no such
+   field. Until it is added, conventions are carried out-of-band (documentation / `repMapName`);
+   the literals below show `repMapConventions` as the proposed field.
+2. **A fallible reconstruction on the load path.** `repMapInverse` is total
+   (`… -> Pattern v -> Pattern v`), so it cannot signal that a lossy map's inverse hit an absent
+   discriminator. The persistence load path therefore needs a *partial* inverse,
+   `reconstruct :: RepresentationMap v -> q v -> Pattern v -> Either DecodeError (Pattern v)`,
+   surfacing `Left (MissingConvention …)` when a required tag is missing and succeeding
+   trivially for faithful maps. `loadVia` binds through it (above).
 
 ### The faithful regime: the Frame/Span two-table encoding
 
@@ -319,14 +341,14 @@ endpoint FKs to "exists somewhere," losing frame-pair correctness; see Alternati
 ```haskell
 byReference :: RepresentationMap Subject      -- by-value Pattern  ↔  Frame/Span by-reference
 byReference = RepresentationMap
-  { name        = "by-value ↔ by-reference (Frame/Span)"
-  , domain      = anyPattern
-  , codomain    = frameSpanRefKind
-  , conventions = [ "Frames stored once; Spans reference Frames by identity"
-                  , "cross-Frame edges externalized as bundle_pair rows (RFC-001 principle 2)" ]
-  , forward     = toByReference
-  , inverse     = resolveByReference
-  , roundTrip   = byReferenceRoundTrip       -- strict on anyPattern with identified subjects
+  { repMapName        = "by-value ↔ by-reference (Frame/Span)"
+  , repMapDomain      = anyPattern
+  , repMapCodomain    = frameSpanRefKind
+  , repMapConventions = [ "Frames stored once; Spans reference Frames by identity"
+                        , "cross-Frame edges externalized as bundle_pair rows (RFC-001 principle 2)" ]
+  , repMapForward     = toByReference
+  , repMapInverse     = resolveByReference
+  , repMapRoundTrip   = byReferenceRoundTrip  -- strict on anyPattern with identified subjects
   }
 ```
 
@@ -352,15 +374,15 @@ in an earlier draft:
 ```haskell
 relationalToGraph :: RepresentationMap Subject   -- relational data ↪ property-graph
 relationalToGraph = RepresentationMap
-  { name        = "relational ↪ property-graph"
-  , domain      = relationalKind
-  , codomain    = graphKind
-  , conventions = [ "each table T -> nodes labeled T; columns -> node properties"
-                  , "foreign-key column -> relationship to the referenced node"
-                  , "M:N junction table -> relationship type; non-key columns -> rel properties" ]
-  , forward     = embedRelationalAsGraph
-  , inverse     = projectGraphAsRelational           -- partial: on the relational sub-kind
-  , roundTrip   = relationalRoundTrip
+  { repMapName        = "relational ↪ property-graph"
+  , repMapDomain      = relationalKind
+  , repMapCodomain    = graphKind
+  , repMapConventions = [ "each table T -> nodes labeled T; columns -> node properties"
+                        , "foreign-key column -> relationship to the referenced node"
+                        , "M:N junction table -> relationship type; non-key columns -> rel properties" ]
+  , repMapForward     = embedRelationalAsGraph
+  , repMapInverse     = projectGraphAsRelational      -- partial: on the relational sub-kind
+  , repMapRoundTrip   = relationalRoundTrip
   }
 ```
 
@@ -380,15 +402,15 @@ minimizes the tags:
 ```haskell
 patternToGraph :: PatternKind Subject -> RepresentationMap Subject
 patternToGraph appDomain = RepresentationMap
-  { name        = "Pattern ↠ native property-graph"
-  , domain      = appDomain
-  , codomain    = graphKind
-  , conventions = [ "binary pattern -> relationship; tag _pk=binary only where it collides with a native relationship"
-                  , "annotation -> self-loop; tag _pk=annotation only where it collides with a self-reference"
-                  , "rich Value (VMap/VArray/VRange/VMeasurement/VTaggedString) -> decomposed sub-nodes or property_json" ]
-  , forward     = projectPatternAsGraph appDomain
-  , inverse     = liftGraphAsPattern appDomain
-  , roundTrip   = graphRoundTripOn appDomain          -- strict on appDomain; tags restore invertibility
+  { repMapName        = "Pattern ↠ native property-graph"
+  , repMapDomain      = appDomain
+  , repMapCodomain    = graphKind
+  , repMapConventions = [ "binary pattern -> relationship; tag _pk=binary only where it collides with a native relationship"
+                        , "annotation -> self-loop; tag _pk=annotation only where it collides with a self-reference"
+                        , "rich Value (VMap/VArray/VRange/VMeasurement/VTaggedString) -> decomposed sub-nodes or property_json" ]
+  , repMapForward     = projectPatternAsGraph appDomain
+  , repMapInverse     = liftGraphAsPattern appDomain
+  , repMapRoundTrip   = graphRoundTripOn appDomain     -- strict on appDomain; tags restore invertibility
   }
 ```
 
@@ -433,11 +455,11 @@ saveVia (patternToGraph appDomain) graphCodec scope p  -- arbitrary pattern into
 
 ### Failure modes
 
-`decode` is **total** — it returns `Either DecodeError`, never throws — and classifies
-failures via `DecodeError`: `KindViolation` (stored data does not satisfy `targetKind`,
-e.g. schema drift), `MissingConvention` (an ambiguous shape under a lossy map lacks its
-discriminator), `MalformedValue` (an unparseable cell), and `DanglingRef` (a reference to an
-absent row). `bundle_pair` endpoints are FK-enforced where the transport supports composite
+The load path is **total** — `decode` and `reconstruct` both return `Either DecodeError` and
+never throw — classifying failures via `DecodeError`: `KindViolation` (stored data does not
+satisfy `targetKind`, e.g. schema drift) and `MalformedValue` (an unparseable cell) arise in
+`decode`; `MissingConvention` (a lossy map's inverse lacks the discriminator needed to invert)
+arises in `reconstruct`; `DanglingRef` (a reference to an absent row) in either. `bundle_pair` endpoints are FK-enforced where the transport supports composite
 FKs, so `DanglingRef` there is a backstop for transports that do not; the `frame_row.elements`
 array is *not* FK-enforceable in standard SQL, so dangling element refs are decode-time
 `DanglingRef` checks regardless of transport. `persist` is atomic at the single-unit

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -343,6 +343,14 @@ relationalToGraph = RepresentationMap
   }
 ```
 
+Note what *neither* story is: **faithful round-trip of an arbitrary RDBMS.** `relationalToGraph`
+is query-interop — it views relational data *as* a graph and makes no claim to reconstruct the
+source database. Faithfully ingesting an RDBMS and getting the same RDBMS back is a third,
+distinct concern (it requires capturing the schema/catalog — PKs, FKs, types, constraints — as
+data, whose natural faithful encoding is the Frame/Span model: table → Frame, foreign key →
+Span, catalog → Frame-of-Frames). That is a relational **source adapter**, separate from
+"persist Pattern into a store," and out of scope for this RFC (Open Question 1).
+
 The genuinely **lossy** projection — an arbitrary pattern onto the *native* graph store
 vocabulary — is also a map, with discriminators emitted only on target shapes whose preimage
 is non-singleton (derivable from `domain`); restricting `domain` to an application's schema
@@ -375,9 +383,9 @@ the canonical form held in Frame/Span storage, round-trip is simply not claimed.
 - `anyPattern` — the document model (≈ lattice top).
 - `relationalKind` — the native relational model. Its predicate is non-trivial because
   relationality is largely about *references* (foreign keys), which are scope-relative rather
-  than locally structural; see Open Questions. If no clean predicate exists, `relationalKind`
-  is defined operationally as the `domain` of `relationalToGraph` — the three-axes story holds
-  either way, since the embedding, not a standalone predicate, is what interop needs.
+  than locally structural. `relationalKind` is therefore defined operationally as the `domain`
+  of `relationalToGraph` — the three-axes story holds either way, since the embedding, not a
+  standalone predicate, is what interop needs (Open Question 1, resolved).
 
 ### Reference Codecs (thin, one `targetKind` each)
 
@@ -471,10 +479,20 @@ is the first port — the immediate need in `aie-matrix`.
 
 ## Open Questions
 
-1. **`relationalKind` expressibility.** Is the native relational model expressible as a
-   `PatternKind` predicate, given foreign keys are scope-relative rather than locally
-   structural? If a clean predicate is impractical, does relational interop need a weaker
-   classification than graph/document, or to be specified only by its embedding map?
+1. **`relationalKind` expressibility, and faithful RDBMS ingestion. — Resolved.** Two
+   concerns were conflated here, and separating them resolves both:
+   - **Predicate sub-question (closed):** the query-interop path (`relationalToGraph`) needs
+     no standalone `relationalKind` *predicate*. `relationalKind` is defined operationally as
+     the embedding's `domain` — recognizing relational-shaped patterns is the embedding's
+     concern, not a separate classifier (see § Target kinds). Foreign keys being scope-relative
+     is precisely why a local structural predicate is the wrong tool.
+   - **Faithful RDBMS round-trip (out of scope):** ingesting an arbitrary RDBMS *as* Pattern
+     and reconstructing the same RDBMS is a different problem from "persist Pattern into a
+     store." It requires capturing the schema/catalog (PKs, FKs, types, constraints) as data,
+     and its natural faithful encoding is the Frame/Span model (table → Frame, FK → Span,
+     catalog → Frame-of-Frames) — the faithful regime, not `relationalToGraph`. It is a
+     relational **source adapter** and belongs in its own future RFC ("RDBMS ⇄ Frame/Span");
+     RFC-011 makes no faithful-RDBMS claim (see § two distinct "relational" stories).
 2. **Batching / transactionality.** `persist` is one-unit-at-a-time. Bulk seeding and
    transactional multi-statement writes need a batch surface (`persistMany`,
    `withTransaction`). `Store`, or a layer above?

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -33,6 +33,44 @@ a real database. Pattern has in-memory operations and a canonical JSON encoding
 (`Gram.JSON`), but no first-class, fidelity-aware way to land a `Pattern v` in a store, in
 a chosen *representation*, and reconstruct it.
 
+### Why a database, not just a blob
+
+Pattern's operations are in-memory: the substrate is a value in RAM. For *durability alone*
+that needs nothing elaborate — serialize the whole `Pattern` to a blob (the `Gram.JSON`
+document encoding) and read it back. The document codec covers exactly this case and is the
+baseline; if everything fits in memory, you are done.
+
+The reason to design for *database* backends is **scale past RAM** — large ≈ more than fits
+in memory. When a Pattern is larger than memory you cannot load it whole, so durability stops
+being the problem and *partial, indexed, and streaming access* becomes the problem. That
+requires a real storage and query engine underneath: Frame/Span tables to fetch one Frame
+without materializing the whole graph-of-graphs, a native graph engine to traverse without
+loading, columnar scans over Subject components without reading every row. A blob can do none
+of these. So the document codec is the honest durability answer *up to* RAM, and the database
+backends earn their keep precisely *past* it (see Open Question 7 on streaming).
+
+### A storage engine, not an object mapper
+
+`Pattern Subject` and its operations are the data model and the query space — the conceptual
+layer. Codecs and Stores are a pluggable *storage* layer, chosen by which queries a workload
+runs, the way Postgres decouples its relational/SQL layer from a pluggable table-access method
+(and, beneath both, Codd's logical/physical data independence). A codec is a **physical
+encoding, not a semantic translation**: there is no second model to reconcile, and the store
+never tries to look like Pattern.
+
+This is the ANSI/SPARC three-schema split:
+
+- **external** — typed views / OO lenses over the model (per-consumer presentation)
+- **conceptual** — `Pattern Subject` + operations (the one model and query algebra)
+- **internal** — codecs + stores (pluggable physical engines)
+
+The two fidelity regimes are roles within the internal layer: faithful backends are
+interchangeable engines (any can hold the whole model; pick by query fit); the lossy
+native-graph backend is a query-optimized replica/index, with the logical truth held in a
+faithful engine. ORM/OGM, by contrast, collapse the external and internal schemas — objects
+*are* the persistence mapping — which is the source of their impedance mismatch (see
+Alternatives).
+
 ### Three axes, not "a codec per backend"
 
 A naïve design writes "the relational codec" and "the graph codec" as parallel siblings.
@@ -492,11 +530,17 @@ tables and do not model a recursive meta-structure or its shape strategy. They r
 candidates to *implement* a `Store` (and a backend `Codec`'s encode/decode against SQL) — they
 are a transport-layer choice, not a substitute for the kind/representation machinery.
 
-**An OGM-style rich object layer** — map `Pattern` to stateful domain objects with
-lazy-loading and an identity map, then persist the objects. Rejected for the reasons the wider
-ORM history and the Haskell ecosystem reject it: it reintroduces the impedance mismatch, adds a
-third source of truth, and centers a mutable object graph that `Pattern` is specifically better
-than. OO ergonomics belong in a *view/lens* over `Pattern`, not in the persistence path.
+**An ORM/OGM-style model translation** — map `Pattern` to/from a second first-class model
+(stateful domain objects with lazy-loading and an identity map, or the store's native model
+dressed up as objects) and reconcile the two. Rejected *at the premise*, not just the
+mechanics: ORM and OGM exist to make one model *look like* another — the store's `M` like the
+application's `O` — and the impedance mismatch is the standing cost of maintaining two models
+and a translation between them. This RFC has **one** model, `Pattern Subject` and its
+operations, and treats backends as pluggable storage engines beneath it (logical/physical
+independence), not as a model to reconcile; a codec is a physical encoding, not a translation.
+The secondary symptoms the Haskell ecosystem also rejects — a third source of truth, a mutable
+object graph `Pattern` is better than — follow from that premise. OO ergonomics, when wanted,
+are an external-schema view/lens over the one model (ANSI/SPARC), never the persistence path.
 
 **One canonical store only** (e.g. "everything is a document"). Simplest, and `documentCodec`
 already covers it as the default. Rejected as the *whole* answer because adoption needs native

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -191,8 +191,11 @@ persisted collection, with operations over it and simple add/remove of contained
 The signature above is the in-RAM baseline — `retrieve` materializes a whole `b`. Past RAM,
 where a result or even a single element exceeds memory, retrieval **streams** instead of
 materializing (the scale extension; the durability baseline materializes, the streaming `Store`
-does not). Random-access **cursor** navigation — which aligns with Zippers — is a later
-addition; near term, streaming only (Open Question 7).
+does not). Streaming changes the shape of both ends — a `retrieve` that yields incrementally
+and a `decode` that consumes incrementally — so the whole-`b` signature above is the baseline,
+not the final word; the streaming surface is settled when that step is built (Step 5).
+Random-access **cursor** navigation — which aligns with Zippers — is deferred beyond that;
+near term, streaming only (Open Question 7).
 
 End-to-end save/load are thin compositions of a `RepresentationMap` chain (shape), a
 `Codec` (bytes), and a `Store` (transport). Use `idMap` when the source is already of the
@@ -231,7 +234,9 @@ discipline** of Frames and Spans serialized directly:
   table*).
 
 "Every table is a label, every join table is a relationship" thus stops being an imposed
-convention and becomes the direct image of RFC-001's principle 2.
+convention and becomes the direct image of RFC-001's principle 2. ("Two-table" here means two
+*kinds* of table — node and edge — realized physically as `frame`/`frame_row` for the node
+side and `span`/`bundle_pair` for the edge side.)
 
 | RFC-001 (in-memory, by-value) | RFC-011 (by-reference storage) |
 |---|---|
@@ -410,8 +415,8 @@ documentCodec :: Codec Value Subject          -- document model ≈ Pattern (lat
 documentCodec = Codec "document" anyPattern patternToValue decodeJSON
   -- decodeJSON :: Value -> Either DecodeError (Pattern Subject), via patternFromValue
 
-frameSpanCodec :: Codec TwoTables Subject      -- the faithful Frame/Span tables (RDBMS / columnar)
-frameSpanCodec = Codec "frame-span" frameSpanRefKind toTwoTables fromTwoTables
+frameSpanCodec :: Codec FrameSpanTables Subject  -- the faithful Frame/Span tables (RDBMS / columnar)
+frameSpanCodec = Codec "frame-span" frameSpanRefKind toFrameSpanTables fromFrameSpanTables
 
 graphCodec :: Codec [GraphOp] Subject          -- native node/rel/property model
 graphCodec = Codec "neo4j" graphKind toGraphOps fromGraphResult
@@ -523,7 +528,18 @@ provide a real `Store [GraphOp] IO` against a Neo4j driver (outside the pure lib
 port directly; `Store` is implemented per language against native drivers. The document codec
 is the first port — the immediate need in `aie-matrix`.
 
+**Step 5 — Streaming retrieval (the past-RAM scale increment).** A streaming `retrieve`
+variant that yields incrementally and an incremental `decode`, for stores whose results or
+elements exceed memory; this step settles the streaming surface left open above. It is the
+scale increment the motivation calls for, sequenced after the core device lands; random-access
+cursors (Zippers) are a later, separate addition (Open Question 7).
+
 ## Open Questions
+
+All seven are dispositioned below. The only live *external* dependency is #3 (scoped identity
+namespaces), a prerequisite gating implementation; #5 and #6 are deliberate deferrals. RFC-011
+may be **accepted as a design** independently of #3, but its identity-dependent implementation
+(upsert, seed-then-own) is gated on that prerequisite landing first.
 
 1. **`relationalKind` expressibility, and faithful RDBMS ingestion. — Resolved.** Two
    concerns were conflated here, and separating them resolves both:

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -186,8 +186,8 @@ convention and becomes the direct image of RFC-001's principle 2.
 | Frame element (Pattern / Portal) | a row: Subject columns + ordered child-FK array |
 | Self-containment (Reading 1) | element FKs reference **only same-frame rows** |
 | Span (relates two Frames) + its Bundle | one `span` row (Span/Bundle Subjects on the row) |
-| Bundle pair-element (cross-Frame edge) | one `span_pair` row: `(span_id, src_ref, tgt_ref, …)` |
-| Externality (edges live in the Span) | edges live in `span_pair`, never in `frame_row` |
+| Bundle pair-element (cross-Frame edge) | one `bundle_pair` row: `(span_id, src_ref, tgt_ref, …)` |
+| Externality (edges live in the Span) | edges live in `bundle_pair`, never in `frame_row` |
 
 Logical schema — column names and relationships are the contract; physical types are
 transport-specific (`array<…>` is `text[]` in Postgres, `LIST` in DuckDB/Arrow; `json` is
@@ -199,26 +199,38 @@ frame(frame_id, root_id)
 frame_row(frame_id, id, labels array<text>, properties json, elements array<id>)
                                           -- ordered FK array = elements; refs stay in-frame
 
--- span-table : cross-module correspondences, externalized (the edge table)
-span(span_id, subject_id, labels array<text>, properties json,
-     frame_a, frame_b, bundle_id?)        -- Span/Bundle Subjects live on this row
-span_pair(span_id, src_ref, tgt_ref, pair_subject_id?, labels array<text>, properties json)
-                                          -- keyed by span_id, cascade-on-delete;
+-- span-table : the Span's Subject + its (0..1) Bundle's Subject, denormalized
+span(span_id, subject_id, labels array<text>, properties json, frame_a, frame_b,
+     bundle_id?, bundle_labels array<text>?, bundle_properties json?)
+                                          -- Span Subject: subject_id/labels/properties
+                                          -- Bundle Subject (if any): bundle_* ; bundle_id is an
+                                          -- attribute, NOT an FK (there is no bundle table)
+
+-- bundle_pair : the Bundle's pair-elements — one row per inter-frame relationship (the edge table)
+bundle_pair(span_id, src_ref, tgt_ref, pair_subject_id?, labels array<text>, properties json)
+                                          -- keyed by span_id (span:bundle is 1:0..1, so span_id
+                                          -- functionally determines the bundle), cascade-on-delete;
                                           -- src_ref ∈ frame_a, tgt_ref ∈ frame_b : real FKs
 ```
 
 **Decisions baked in (settled in design review):**
 
+- **Span : Bundle is 1:(0..1)**, fixed by RFC-001 (the Bundle is the Span's optional third
+  element). Multiple correspondence-sets between the same two Frames are expressed as multiple
+  *Spans*, not multiple Bundles. The 1:N lives one level down — **Bundle : pair-elements** —
+  and that is the `bundle_pair` table (many rows per span).
 - **Span and Bundle identities live on the `span` row**, not as separate entities — flatter
-  to query.
+  to query, and valid precisely because span:bundle is 1:(0..1). There is **no `bundle` table**:
+  the Bundle's Subject is the `bundle_*` columns, its pair-elements are the `bundle_pair` rows.
 - **Pair-elements are keyed by `span_id` and materialized per span**, not shared by
   `bundle_id`. This makes each span self-contained — Frame self-containment applied to the
   edge table — so `ON DELETE CASCADE` works, endpoint FKs are declarable (a bound span has
   a single valid frame pair), and concurrent writers do not contend on shared edge rows.
-- **`bundle_id` is retained as a non-enforced grouping attribute** (a column, not an FK),
-  so the in-memory *shared* Bundle form (RFC-001 allows Bundle sharing) can be reconstituted
-  on read when two spans carry identical pairs under the same id — without the database ever
-  depending on it.
+- **`bundle_id` is a non-enforced attribute** (a column, not an FK — it points at no table),
+  retained so the in-memory *shared* Bundle form (RFC-001 allows Bundle sharing) can be
+  reconstituted on read when two spans carry identical pairs under the same id — without the
+  database ever depending on it. A third (`bundle`) table would be needed only to reintroduce
+  the rejected shared-bundle semantics; see Alternatives.
 - **Escape hatch** for a genuinely large, shared correspondence: promote the Bundle to a
   first-class stored entity (it is a `Pattern Subject`, so it gets its own `frame_row`s)
   with an explicit, managed lifecycle. Opt-in, eyes-open sharing — not the implicit default
@@ -235,7 +247,7 @@ byReference = RepresentationMap
   , domain      = anyPattern
   , codomain    = frameSpanRefKind
   , conventions = [ "Frames stored once; Spans reference Frames by identity"
-                  , "cross-Frame edges externalized as span_pair rows (RFC-001 principle 2)" ]
+                  , "cross-Frame edges externalized as bundle_pair rows (RFC-001 principle 2)" ]
   , forward     = toByReference
   , inverse     = resolveByReference
   , roundTrip   = byReferenceRoundTrip       -- strict on anyPattern with identified subjects
@@ -341,7 +353,7 @@ saveVia (patternToGraph appDomain) graphCodec scope p  -- arbitrary pattern into
 failures via `DecodeError`: `KindViolation` (stored data does not satisfy `targetKind`,
 e.g. schema drift), `MissingConvention` (an ambiguous shape under a lossy map lacks its
 discriminator), `MalformedValue` (an unparseable cell), and `DanglingRef` (an `elements` or
-`span_pair` endpoint FK references an absent row — the integrity hazard that array-of-FK and
+`bundle_pair` endpoint FK references an absent row — the integrity hazard that array-of-FK and
 the edge table cannot have the database enforce in every transport). `persist` is atomic at
 the single-unit granularity; multi-statement transactional and bulk writes are deferred
 (Open Question 2).
@@ -375,8 +387,8 @@ Observable, regardless of file/package layout:
 2. Seeding a multi-Frame pattern (e.g. an `aie-matrix` NPC + map + calendar config) via
    `saveVia byReference frameSpanCodec`, then `loadVia`, yields a `Pattern` structurally
    equal to the original — including cross-Frame correspondences, which appear as
-   `span_pair` rows and never inside any frame.
-3. Deleting a `span` row removes exactly its `span_pair` rows (cascade) and no `frame_row`s.
+   `bundle_pair` rows and never inside any frame.
+3. Deleting a `span` row removes exactly its `bundle_pair` rows (cascade) and no `frame_row`s.
 4. `decode` of a row set with a dangling endpoint FK returns `Left (DanglingRef …)`, never
    throws.
 
@@ -413,7 +425,7 @@ is the first port — the immediate need in `aie-matrix`.
 3. **Identity and upsert.** `StoreKey` vs. `Subject.identity`. When the store owns identity
    (post-seed), how does decode reconcile store keys with pattern identities? Likely a
    per-codec identity strategy, coordinated with RFC-010 reconciliation.
-4. **Shared-Bundle reconstruction.** On read, should identical `span_pair` sets under one
+4. **Shared-Bundle reconstruction.** On read, should identical `bundle_pair` sets under one
    `bundle_id` be reconstituted as a shared in-memory Bundle automatically, or only on
    explicit request? Default leans explicit, to keep the read path simple.
 5. **Representation registry.** A catalog of `(model × strategy) → (map chain, codec)` so

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -549,9 +549,12 @@ is the first port — the immediate need in `aie-matrix`.
    are *not* automatically coalesced into a shared in-memory Bundle. Reconstituting sharing is
    a deliberate, opt-in operation the caller requests — keeping the read path simple,
    predictable, and free of implicit cross-span coupling.
-5. **Representation registry.** A catalog of `(model × strategy) → (map chain, codec)` so
-   callers pick by desired qualities. **Deferred:** park until at least two embeddings exist;
-   until then, representations are assembled explicitly at call sites.
+5. **Representation registry. — Resolved: deferred (deliberate).** A catalog of
+   `(model × strategy) → (map chain, codec)` letting callers pick a representation by desired
+   qualities is *not* part of this RFC. Until at least two real embeddings exist and the
+   composition ergonomics are understood, a registry would be premature abstraction over a
+   single example. Representations are assembled explicitly at call sites via `saveVia` /
+   `loadVia`; the registry is revisited once there is enough variety to generalize from.
 6. **Schema-driven generation.** How much of the kinds, table layout, and graph conventions
    can `Gram.Schema` generate vs. hand-write? Park until the hand-written versions are stable.
 7. **Streaming / partial load.** Large stores will not fit one `Pattern` in memory. A

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -179,6 +179,12 @@ class Monad m => Store b m where
   retrieve :: StoreQuery b -> m b
 ```
 
+`Store` is deliberately minimal — single-unit `persist`/`retrieve`. **Batching and
+transactionality are a layer above**, not methods here: bulk seeding and multi-statement
+atomic writes (`persistMany`, `withTransaction`) are orchestration over a `Store`, transport-
+specific and orthogonal to the codec's shape concern. Keeping them out of the interface keeps
+the boundary thin and every backend's `Store` instance trivial (Open Question 2).
+
 End-to-end save/load are thin compositions of a `RepresentationMap` chain (shape), a
 `Codec` (bytes), and a `Store` (transport). Use `idMap` when the source is already of the
 codec's `targetKind`:
@@ -420,7 +426,8 @@ absent row). `bundle_pair` endpoints are FK-enforced where the transport support
 FKs, so `DanglingRef` there is a backstop for transports that do not; the `frame_row.elements`
 array is *not* FK-enforceable in standard SQL, so dangling element refs are decode-time
 `DanglingRef` checks regardless of transport. `persist` is atomic at the single-unit
-granularity; multi-statement transactional and bulk writes are deferred (Open Question 2).
+granularity; multi-statement transactional and bulk writes are a layer above `Store`
+(Open Question 2, resolved).
 
 ### The seed-then-own use case
 
@@ -493,9 +500,11 @@ is the first port — the immediate need in `aie-matrix`.
      catalog → Frame-of-Frames) — the faithful regime, not `relationalToGraph`. It is a
      relational **source adapter** and belongs in its own future RFC ("RDBMS ⇄ Frame/Span");
      RFC-011 makes no faithful-RDBMS claim (see § two distinct "relational" stories).
-2. **Batching / transactionality.** `persist` is one-unit-at-a-time. Bulk seeding and
-   transactional multi-statement writes need a batch surface (`persistMany`,
-   `withTransaction`). `Store`, or a layer above?
+2. **Batching / transactionality. — Resolved: a layer above.** `persist` stays
+   one-unit-at-a-time; `Store` does not grow a batch/transaction surface. Bulk seeding and
+   multi-statement atomic writes (`persistMany`, `withTransaction`) are orchestration *over* a
+   `Store` — transport-specific and orthogonal to encoding — so they live above the boundary,
+   keeping `Store` instances trivial and the scope tidy (see § Transport is a separate concern).
 3. **Identity and upsert.** `StoreKey` vs. `Subject.identity`. When the store owns identity
    (post-seed), how does decode reconcile store keys with pattern identities? Likely a
    per-codec identity strategy, coordinated with RFC-010 reconciliation.

--- a/proposals/rfc/RFC-011-codec-persistence.md
+++ b/proposals/rfc/RFC-011-codec-persistence.md
@@ -186,6 +186,14 @@ atomic writes (`persistMany`, `withTransaction`) are orchestration over a `Store
 specific and orthogonal to the codec's shape concern. Keeping them out of the interface keeps
 the boundary thin and every backend's `Store` instance trivial (Open Question 2).
 
+Conceptually a `Store` is the **persistent analog of an RFC-001 Frame**: a handle over a
+persisted collection, with operations over it and simple add/remove of contained elements.
+The signature above is the in-RAM baseline — `retrieve` materializes a whole `b`. Past RAM,
+where a result or even a single element exceeds memory, retrieval **streams** instead of
+materializing (the scale extension; the durability baseline materializes, the streaming `Store`
+does not). Random-access **cursor** navigation — which aligns with Zippers — is a later
+addition; near term, streaming only (Open Question 7).
+
 End-to-end save/load are thin compositions of a `RepresentationMap` chain (shape), a
 `Codec` (bytes), and a `Store` (transport). Use `idMap` when the source is already of the
 codec's `targetKind`:
@@ -561,8 +569,18 @@ is the first port — the immediate need in `aie-matrix`.
    immature to automate. The codecs and kinds are hand-written first; only after exercising
    several of them — and seeing what genuinely recurs — is there expertise to generate from.
    Revisit once the hand-written versions are stable.
-7. **Streaming / partial load.** Large stores will not fit one `Pattern` in memory. A
-   streaming codec variant, or a `Store`-level cursor + fold?
+7. **Streaming vs. cursors. — Resolved: streaming now, cursors (Zippers) later.** *(The
+   earlier wording was awkward.)* The concern is that a store holds Patterns too large for
+   memory — a query result, or even a single element, may exceed RAM — not that "one Pattern
+   won't fit." A `Store` is the persistent analog of an RFC-001 Frame: a handle over a
+   persisted collection, exposing operations over it plus simple add/remove of contained
+   elements (see § Transport is a separate concern). Because results and elements can exceed
+   RAM, the near-term answer is **streaming** retrieval — incremental, never materializing the
+   whole value — which is the simpler model and pairs with the scale motivation (durability
+   baseline materializes in RAM; the streaming `Store` is the past-RAM extension). Random-access
+   **cursors** are deferred: they align closely with **Zippers** (a focus + surrounding context
+   over an immutable Pattern), so the cursor surface should follow the in-memory Zipper rather
+   than be invented here. Near term: streaming.
 
 ## Alternatives
 


### PR DESCRIPTION
## Summary

Adds **RFC-011 (draft)**, proposing `Codec` as the device for persisting `Pattern Subject` to external stores — the missing adoption-grade persistence story. Persistence is factored along **three independent axes**:

- **Target model** → a `PatternKind` (RFC-007)
- **Encoding strategy** → a `RepresentationMap` chain (RFC-007)
- **Transport** → a separate `Store`

A `Codec` binds one kind to one transport and is *faithful for that kind by construction*; fidelity is a property of the map chain, not a codec flag.

## Why

The downstream `aie-matrix` app currently hand-rolls `Pattern → OO → Neo4j`, which is bespoke, lossy, and unreusable across ports. This RFC replaces that with declared, testable, composable representations.

## Key design decisions

- **Two fidelity regimes.** *Faithful* — the **Frame/Span two-table encoding**, the relational/columnar realization of RFC-001's by-reference storage form, where Frame/Span *externality* (a Frame doesn't hold its cross-Frame edges; the Span does) **is** the node-table/edge-table split. *Lossy* — projection onto a native graph store's smaller vocabulary, via declared discriminator conventions or an explicit one-way projection. A `RepresentationMap` stays always-invertible on its domain.
- **Span/Bundle identities on the `span` row.**
- **Pair-elements materialized per `span_id`** (not shared by `bundle_id`): cascade-on-delete works, endpoint FKs are declarable, no write contention. `bundle_id` is retained as a non-enforced attribute for read-time shared-Bundle reconstruction; a promote-to-entity escape hatch covers genuinely shared large bundles.
- **Two distinct "relational" stories separated:** Pattern-encoded-*into* relational/columnar storage (faithful) vs. the native relational *model* as a graph subset (`relationalToGraph` interop).

## Dependencies

Depends on RFC-001 (Frames and Spans), RFC-007 (RepresentationMap/PatternKind), RFC-004 (GraphClassifier kinds). RFC-011 is explicitly the database-backed layer RFC-001 defers "above pattern-hs" — the substrate stays in-memory.

## Reviewer notes

- Drafted with `rfc-creator` and iterated through two `rfc-review` passes; all blocking issues resolved.
- **Open Question #1** is the one genuinely unresolved point: whether the native relational model is expressible as a `PatternKind` predicate (FKs are scope-relative), or should be defined operationally via its embedding map.
- The second commit tracks RFC-process tooling: aligns the `rfc-creator` skill template with the repo's actual RFC conventions and begins tracking the previously-untracked `rfc-review` skill. Happy to split this out if it shouldn't ride on a proposal branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)